### PR TITLE
Hotfix/medicao ano periodos escolares

### DIFF
--- a/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
+++ b/src/components/screens/LancamentoInicial/PeriodoLancamentoMedicaoInicial/index.jsx
@@ -376,7 +376,8 @@ export default () => {
       const escola =
         meusDados.vinculo_atual && meusDados.vinculo_atual.instituicao;
       const response_vinculos = await getVinculosTipoAlimentacaoPorEscola(
-        escola.uuid
+        escola.uuid,
+        { ano: getYear(mesAnoSelecionado).toString() }
       );
 
       getListaDiasSobremesaDoceAsync(escola.uuid);


### PR DESCRIPTION
# Este PR:
- corrige bug que não carregava os períodos escolares corretamente na medição inicial