### PR TITLE
fix(125188): corrige bugs encontrados pelo QA

### DIFF
--- a/src/components/screens/PreRecebimento/AlterarCronograma/index.jsx
+++ b/src/components/screens/PreRecebimento/AlterarCronograma/index.jsx
@@ -420,7 +420,7 @@ export default ({ analiseSolicitacao }) => {
                                 label="Quantidade Total Programada"
                                 name="quantidade_total"
                                 className="input-busca-produto"
-                                disabled={false}
+                                disabled={true}
                                 agrupadorMilharComDecimal
                                 required
                                 validate={required}
@@ -569,7 +569,9 @@ export default ({ analiseSolicitacao }) => {
                         handleSubmitCronograma={(justificativa) =>
                           handleSubmitCronograma(values, justificativa)
                         }
-                        podeSubmeter={Object.keys(errors).length === 0}
+                        podeSubmeter={
+                          Object.keys(errors).length === 0 && restante === 0
+                        }
                         disabledDinutre={disabledDinutre(values)}
                         disabledDilog={disabledDilog(values)}
                       />


### PR DESCRIPTION
Foi solicitado desativar o campo Quantidade Total Programada visto não ser devida sua alteração na tela de Alteração do Cronograma de Entrega, e que o botão se salvar só fique disponível quando o restante, que é o calculo quantidade total programada, subtraindo as quantidades informadas em cada etapa do cronograma, de for zero.