### PR TITLE
chore: adiciona lib redux-mock-store ao projeto para testes unitários

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "node-localstorage": "^1.3.1",
         "prettier": "^2.8.8",
         "react-scripts": "^5.0.1",
+        "redux-mock-store": "^1.5.5",
         "sass": "^1.83.0"
       }
     },
@@ -21815,6 +21816,18 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/redux-mock-store": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.5.tgz",
+      "integrity": "sha512-YxX+ofKUTQkZE4HbhYG4kKGr7oCTJfB0GLy7bSeqx86GLpGirrbUWstMnqXkqHNaQpcnbMGbof2dYs5KsPE6Zg==",
+      "dev": true,
+      "dependencies": {
+        "lodash.isplainobject": "^4.0.6"
+      },
+      "peerDependencies": {
+        "redux": "*"
+      }
     },
     "node_modules/redux-multi": {
       "version": "0.1.12",

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "node-localstorage": "^1.3.1",
     "prettier": "^2.8.8",
     "react-scripts": "^5.0.1",
+    "redux-mock-store": "^1.5.5",
     "sass": "^1.83.0"
   },
   "setupFiles": [


### PR DESCRIPTION
Este PR adiciona a dependência `redux-mock-store` ao projeto para permitir a execução de testes unitários que utilizam simulação de store Redux.

A biblioteca foi instalada com `--save-dev` e registrada corretamente nos arquivos `package.json` e `package-lock.json`.

Favor revisar. Obrigado!