### PR TITLE
feature/127557-filtro-relatorio-frontend-eudes

### DIFF
--- a/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/components/Filtros/index.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/components/Filtros/index.jsx
@@ -159,9 +159,17 @@ export const Filtros = ({ ...props }) => {
                       value: tipo_unidade.uuid,
                     }))}
                     selected={values.tipos_unidades_selecionadas || []}
-                    onSelectedChanged={(value) =>
-                      form.change("tipos_unidades_selecionadas", value)
-                    }
+                    onSelectedChanged={async (value) => {
+                      form.change("tipos_unidades_selecionadas", value);
+
+                      const { lote } = form.getState().values; // lote atual
+                      if (lote) {
+                        await getUnidadesEducacionaisAsync({
+                          lote,
+                          tipos_unidades_selecionadas: value,
+                        });
+                      }
+                    }}
                     overrideStrings={{
                       search: "Busca",
                       selectSomeItems: "Selecione o tipo de unidade",

--- a/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/components/Filtros/index.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/components/Filtros/index.jsx
@@ -35,10 +35,21 @@ export const Filtros = ({ ...props }) => {
     setUnidadesEducacionais([]);
     let data = values;
     const response = await getUnidadesEducacionaisComCodEol(data);
+    console.log(response);
     if (response.status === HTTP_STATUS.OK) {
+      if (response.data.mensagem) {
+        setUnidadesEducacionais([
+          {
+            label: response.data.mensagem,
+            value: "__no_result__",
+            disabled: true,
+          },
+        ]);
+        return;
+      }
       setUnidadesEducacionais(
         response.data.map((unidade) => ({
-          label: unidade.codigo_eol_escola,
+          label: `${unidade.codigo_eol_escola}`,
           value: unidade.uuid,
         }))
       );

--- a/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/components/Filtros/index.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/components/Filtros/index.jsx
@@ -35,7 +35,6 @@ export const Filtros = ({ ...props }) => {
     setUnidadesEducacionais([]);
     let data = values;
     const response = await getUnidadesEducacionaisComCodEol(data);
-    console.log(response);
     if (response.status === HTTP_STATUS.OK) {
       if (response.data.mensagem) {
         setUnidadesEducacionais([


### PR DESCRIPTION
Melhorias no Relatório de Dietas Autorizadas (Frontend)

🎯 Task: #127557

Funcionalidade implementada:

Ao acessar o SIGPAE com usuário que tenha acesso ao Relatório de Dietas Autorizadas:
- Navegação: Menu lateral > Dieta Especial > Relatórios > Relatório de Dietas Autorizadas

Foram implementadas as seguintes melhorias na interface:

1. O campo de Unidades Educacionais agora exibe apenas as escolas que são compatíveis com o Tipo de Unidade e a DRE/Lote selecionados.

2. Caso a combinação de filtros não gere nenhum resultado, o sistema exibe a mensagem:
   > "Não existem resultados para os filtros selecionados"

3. As opções "DIRETA" e "MISTA" foram ocultadas do filtro "Tipo de Gestão".

Favor revisar.