### PR TITLE
fix: desabilita checkbox "Todas" quando não há Unidades Educacionais (ajuste na história 127557)

### DIFF
--- a/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/components/Filtros/index.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioDietasAutorizadas/components/Filtros/index.jsx
@@ -249,7 +249,11 @@ export const Filtros = ({ ...props }) => {
                           "Todos as unidades estão selecionadas",
                         selectAll: "Todas",
                       }}
-                      disabled={filtros.lotes.length > 1 && !values.lote}
+                      disabled={
+                        (unidadesEducacionais.length === 1 &&
+                          unidadesEducacionais[0].value === "__no_result__") ||
+                        (filtros.lotes.length > 1 && !values.lote)
+                      }
                     />
                   </Spin>
                 </div>


### PR DESCRIPTION
Ajuste realizado com base em feedback do QA (Leandro) na história 127557.

Quando o filtro "Tipo de Unidade" e "DRE/Lote" não retorna Unidades Educacionais, a mensagem "Não existem resultados para os filtros selecionados" já era exibida corretamente.

Este PR complementa esse comportamento, desabilitando o checkbox "Todas" no seletor de Unidades Educacionais, evitando erros ao clicar nessa opção sem dados disponíveis o que ocasionava erro.

Favor, revisar!