### PR TITLE
Feature/upgrade-libs-front-eudes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "0.1.16",
       "hasInstallScript": true,
       "dependencies": {
-        "@ckeditor/ckeditor5-build-classic": "^35.4.0",
-        "@ckeditor/ckeditor5-react": "^5.0.6",
+        "@ckeditor/ckeditor5-build-classic": "^44.1.0",
+        "@ckeditor/ckeditor5-react": "^9.3.1",
         "@khanacademy/react-multi-select": "^0.3.3",
-        "@sentry/browser": "^7.42.0",
+        "@sentry/browser": "^9.29.0",
         "@types/jest": "^29.5.4",
         "@types/node": "^22.15.19",
         "@types/react": "^18.3.21",
@@ -20,7 +20,7 @@
         "@typescript-eslint/typescript-estree": "^6.5.0",
         "ajv": "^8.17.1",
         "ajv-keywords": "^5.1.0",
-        "antd": "^5.22.4",
+        "antd": "^5.26.1",
         "axios": "^1.6.2",
         "axios-mock-adapter": "^1.21.1",
         "bootstrap": "^5.3.2",
@@ -2137,478 +2137,817 @@
       "license": "MIT"
     },
     "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-35.4.0.tgz",
-      "integrity": "sha512-0o0nkggKYwjx60Ge7GGuJp2jJGwGW9LlAOZEVPTMRG8b/uSzMNLHyCChKeakRO4z7tiopJM6o9Y8sfbDM/nKpA==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-adapter-ckfinder/-/ckeditor5-adapter-ckfinder-44.1.0.tgz",
+      "integrity": "sha512-RCamOkjMHlhUg7MhRbP/ZZJ7mq0zk1hj6Hg25efv22WHb2SNnesiwzLtYoyc6ess72/1CYpgZPfamhxsOTXoMA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-upload": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-alignment": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-alignment/-/ckeditor5-alignment-44.1.0.tgz",
+      "integrity": "sha512-t+xIuGiG9pvG4lkglSQfXwoZU9zCPUvrBYISI8G0WAJXdWdmyWUN2Vj84CKQQ6LRgnqq/eybSR2O2l02psgtZw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-autoformat": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-35.4.0.tgz",
-      "integrity": "sha512-4vAOaoiziR2XN8KmismiBiknCeOYKtskW8yQnSrFWUX3Fkok3KrHaRFr48AbIN4pHI2xTMKPLeMLeRtZd8tTVw==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autoformat/-/ckeditor5-autoformat-44.1.0.tgz",
+      "integrity": "sha512-JHJh+iD9//sYsVlwdGZTV+ScPMlWjqFuR7xwF2QbU7xYGMqTy4mPnFvkT6fF73e3PZvtAzgENLU45pUAS9oo/A==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-autosave": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-autosave/-/ckeditor5-autosave-44.1.0.tgz",
+      "integrity": "sha512-KlkJcgu5THkfdwzYzVa9zKkADGd8J5VW5kRrRSK4oJYONA5mmiZ9UsIcoIk2QbGnDGnZW1Iih5Pjrvz0HYjIKw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-basic-styles": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-35.4.0.tgz",
-      "integrity": "sha512-6JkoplYMwIHN1E/w3DoY0i95B41sbGwsNAtlvx6qaBvNKkLu4rRCtiBUJDnx8qZxxQXHih5ZOw8bUQHl4mt8hw==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-basic-styles/-/ckeditor5-basic-styles-44.1.0.tgz",
+      "integrity": "sha512-/pZ0wBdXlv8AX43O/nZ4ENg8Xk/SwZZMAJKKVZa3SwtxNRmeGYTNKIEQEQouWF1PLz3SEZ8L5sS/j9AYX7f5Xw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "ckeditor5": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-block-quote": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-35.4.0.tgz",
-      "integrity": "sha512-AXoJhSVwl/RSelmxqxMcLq0VUXubjEvMc32xvF6CyUkc/vlSkZec6noznXyVo0P5TXOxsFbzwFAdBOSFTFjD+A==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-block-quote/-/ckeditor5-block-quote-44.1.0.tgz",
+      "integrity": "sha512-mApNvTckUbAjeHFaPg7+Je3zTkJDDsM5FWNJJuzaRhl5TBvyW9BM+p7AN8B9cx+pj2Srzlbu+056c0jg4ibCIw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-enter": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-bookmark": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-bookmark/-/ckeditor5-bookmark-44.1.0.tgz",
+      "integrity": "sha512-gzUOspXUb4sN308JbeVWLGxGdFHeYpobiBn8Zj2/Niw6y+/4ZQfssn7fLhKnoHM12bzoxYYq3DvcMUrs78Ukvg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "ckeditor5": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-build-classic": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-35.4.0.tgz",
-      "integrity": "sha512-DDvhtoOggo2B7/M+XPReIkFOvkXzzjTP3d4dzakODIFhZ5Y633U0NlIwTeMP/KVvTfzmesW9FJzER0fbVosQgA==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-build-classic/-/ckeditor5-build-classic-44.1.0.tgz",
+      "integrity": "sha512-/zuF39CLlRz0+15yW2fOeopJ1Dasfb2kOhyNbyLnFhaYPvAGZjqAlepYdRXuQRfjclYURimHlZbvIlzALqG2EA==",
+      "deprecated": "The predefined builds are no longer maintained. Check the https://ckeditor.com/docs/ckeditor5/latest/updating/nim-migration/predefined-builds.html page for the details.",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-adapter-ckfinder": "^35.4.0",
-        "@ckeditor/ckeditor5-autoformat": "^35.4.0",
-        "@ckeditor/ckeditor5-basic-styles": "^35.4.0",
-        "@ckeditor/ckeditor5-block-quote": "^35.4.0",
-        "@ckeditor/ckeditor5-ckbox": "^35.4.0",
-        "@ckeditor/ckeditor5-ckfinder": "^35.4.0",
-        "@ckeditor/ckeditor5-cloud-services": "^35.4.0",
-        "@ckeditor/ckeditor5-easy-image": "^35.4.0",
-        "@ckeditor/ckeditor5-editor-classic": "^35.4.0",
-        "@ckeditor/ckeditor5-essentials": "^35.4.0",
-        "@ckeditor/ckeditor5-heading": "^35.4.0",
-        "@ckeditor/ckeditor5-image": "^35.4.0",
-        "@ckeditor/ckeditor5-indent": "^35.4.0",
-        "@ckeditor/ckeditor5-link": "^35.4.0",
-        "@ckeditor/ckeditor5-list": "^35.4.0",
-        "@ckeditor/ckeditor5-media-embed": "^35.4.0",
-        "@ckeditor/ckeditor5-paragraph": "^35.4.0",
-        "@ckeditor/ckeditor5-paste-from-office": "^35.4.0",
-        "@ckeditor/ckeditor5-table": "^35.4.0",
-        "@ckeditor/ckeditor5-typing": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "44.1.0",
+        "@ckeditor/ckeditor5-autoformat": "44.1.0",
+        "@ckeditor/ckeditor5-basic-styles": "44.1.0",
+        "@ckeditor/ckeditor5-block-quote": "44.1.0",
+        "@ckeditor/ckeditor5-ckbox": "44.1.0",
+        "@ckeditor/ckeditor5-ckfinder": "44.1.0",
+        "@ckeditor/ckeditor5-cloud-services": "44.1.0",
+        "@ckeditor/ckeditor5-easy-image": "44.1.0",
+        "@ckeditor/ckeditor5-editor-classic": "44.1.0",
+        "@ckeditor/ckeditor5-essentials": "44.1.0",
+        "@ckeditor/ckeditor5-heading": "44.1.0",
+        "@ckeditor/ckeditor5-image": "44.1.0",
+        "@ckeditor/ckeditor5-indent": "44.1.0",
+        "@ckeditor/ckeditor5-link": "44.1.0",
+        "@ckeditor/ckeditor5-list": "44.1.0",
+        "@ckeditor/ckeditor5-media-embed": "44.1.0",
+        "@ckeditor/ckeditor5-paragraph": "44.1.0",
+        "@ckeditor/ckeditor5-paste-from-office": "44.1.0",
+        "@ckeditor/ckeditor5-table": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckbox": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-35.4.0.tgz",
-      "integrity": "sha512-kpEleQLsu3/nyvc46zkWBp3EvvxinnQfmwvi52h+FLbbI0TE0dxadRppQHZjHXd4yw29N6B1ePeMAVFRX1iYjQ==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckbox/-/ckeditor5-ckbox-44.1.0.tgz",
+      "integrity": "sha512-J+vJckr25Oi3KjJcTYIIUFa2KIXHitknW8iNPegavCV/FFNieTezvvpjJzROlWRiy+U7CRYvgrNbSJXHx5pR6Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-upload": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "blurhash": "2.0.5",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ckfinder": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-35.4.0.tgz",
-      "integrity": "sha512-PeA3PA1c1JGn9f+rZlnWHSuXUU4DjWU4oUp5tMWAtS8OV1srJ2DbU/+Z/WZHO4jmDMfQX9XmN5B/sdLvTQ7ZjQ==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ckfinder/-/ckeditor5-ckfinder-44.1.0.tgz",
+      "integrity": "sha512-oRWHiejta6irRuO78KmtQEiYRrzcad+BycTrFsLRCIZp0hzKx5Vp5olAhXodX+d8gZaV8fJJpswdK0LTjrfKNA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-clipboard": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-35.4.0.tgz",
-      "integrity": "sha512-B6rIQxvOrHvO9TZRC8JA0wKk+IfN880UJkYIg1qlhf9HFNVjdVbtHaiCsPD+TzGmQN3XHXfNjgjabGRIn0iZmw==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-clipboard/-/ckeditor5-clipboard-44.1.0.tgz",
+      "integrity": "sha512-Z5P1P6ATLVy/c7AvI3Akt3mEqQfCnhZmz4EdAS7sF34WTayrHQ/TQjdte/0mN+6LXcQV1whhXe1xLM7GVsG+bg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "^35.4.0",
-        "@ckeditor/ckeditor5-engine": "^35.4.0",
-        "@ckeditor/ckeditor5-utils": "^35.4.0",
-        "@ckeditor/ckeditor5-widget": "^35.4.0",
-        "lodash-es": "^4.17.11"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-cloud-services": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-35.4.0.tgz",
-      "integrity": "sha512-iavLfEKx0GVPMIyPnnOlD9TCVVLIrwp1dCQAfO3A7WUySiLBcC7ShJ+6Bm00CVQQE6VtrYOevrKN/RcRzImzHw==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-cloud-services/-/ckeditor5-cloud-services-44.1.0.tgz",
+      "integrity": "sha512-3Nr8EM6CyRpNkmm+7tbhg/4H16SY5Tqo0TLGHtXdyRxx7y2GLev5OsN01qBhSSGifALTCHyOWymxt5Qo9V5wXg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-code-block": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-code-block/-/ckeditor5-code-block-44.1.0.tgz",
+      "integrity": "sha512-2z4ULLehgMjwxvo0a26UkA2p3MdDITGVDpt7FZkO+P9XCim/j5DdXK4/xVNXLbrOifpFq/5kfrAZvjDX0lPMIw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "44.1.0",
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-enter": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-core": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-35.4.0.tgz",
-      "integrity": "sha512-Rf0H7C4inCj/YC8aii0cT7TC/IuBIQ+tXmu9qd8/1BJ/rz1MCHXtBPApjTbFp33OE3aOFB5+NUaKt05k/dL3OA==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-core/-/ckeditor5-core-44.1.0.tgz",
+      "integrity": "sha512-vBxHT/g37uWM5QKj0i7++clGd85htX9rPtlqzjz3I26NJQvcKCmT39Szv3oPFzAJKuUaqKso5iLq+Sw+VtQRBg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-engine": "^35.4.0",
-        "@ckeditor/ckeditor5-ui": "^35.4.0",
-        "@ckeditor/ckeditor5-utils": "^35.4.0",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-watchdog": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-easy-image": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-35.4.0.tgz",
-      "integrity": "sha512-DRCQ/zh2Ul0f7RrSBG3WYKnZbrU2jj1RazX4qZM1b1WlM81y7+i+Rnp209JIT9TnlrTdYJy2EUY17YHughuyzA==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-easy-image/-/ckeditor5-easy-image-44.1.0.tgz",
+      "integrity": "sha512-hmn9MmVebb/abTBq1ci2fYi7uK93Dt2F3lDYErqsFWCxZ4S2PQW3+qON44E5phE9aDKOLEZ/B61niGrLgcWS5g==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-upload": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-balloon": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-balloon/-/ckeditor5-editor-balloon-44.1.0.tgz",
+      "integrity": "sha512-BVxO3WECurMZEhxIVb2JMqeMcqaqefvc/YfrWNRriVyK7muW47EH74IIZdCXSm7g5i0npEIk808sKqA0t/xR0g==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-editor-classic": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-35.4.0.tgz",
-      "integrity": "sha512-EqAqFD/5oPtDMU2AoH3eJaDplcS8MxfkiRQ5hzeC1JeIPT94w5FCHnB4SAkjLPDnlyZnBWOOYdZSuln2TRIbEw==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-classic/-/ckeditor5-editor-classic-44.1.0.tgz",
+      "integrity": "sha512-rZtJ1KpJGxW8iWE0wVhp9giiYiu3XypjsmthkK8oeMf4+8wTr3ySncLKKts3/BDiAcFdJnog5lv5LQbrAVqO+Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-decoupled": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-decoupled/-/ckeditor5-editor-decoupled-44.1.0.tgz",
+      "integrity": "sha512-pRnDrPVyIM4uCLCjhgzvRk4v63Cc1u9Nc21yx1igswvxAfhGx2BMO+JiC6+8PAHT/mOSbgFB83N+A823sms3uA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-inline": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-inline/-/ckeditor5-editor-inline-44.1.0.tgz",
+      "integrity": "sha512-NglsnVkzioMU9XirmjyTM/DKSL/rzkBBwFaZFiTVyGfhuVzTUClPxGtxKOlML2v0Mtqg/OdRUMPMIo+qtjymeQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-editor-multi-root": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-editor-multi-root/-/ckeditor5-editor-multi-root-44.1.0.tgz",
+      "integrity": "sha512-NAMBGIDn/xMGHXv2IeLRDa84yW9OwHri9H5NdJJ4F+gFtiQbOhIhTQj4nZ8TuLIaYr2NOUrTpTrkw3frgd0lLg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-engine": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-35.4.0.tgz",
-      "integrity": "sha512-67QKtUGJeLM072h9qURvzczYGU3ecuxR9LLmM4dffnV+PBNQ9e8RDCY7PuuEP0pplmAUI6/XqoZJIbk6h7ZV3Q==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-engine/-/ckeditor5-engine-44.1.0.tgz",
+      "integrity": "sha512-+149hsqfZX+Q+ho7P64XUrIpkLqX2jGBuEWjC2ZZYujv1ZIOWOMihkpJL8jE6Vcplee6vsTXGSj2sIHNoOp+3g==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-utils": "^35.4.0",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-enter": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-35.4.0.tgz",
-      "integrity": "sha512-y95RnA/Gw72e220PJKVwNbwPzX4SRs82/rXu1jVyJXty7CcEZqqfyRtW6odICAXr5eKI5XKgzFgpFYULL3D9Nw==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-enter/-/ckeditor5-enter-44.1.0.tgz",
+      "integrity": "sha512-NmtqxEov25rYRN8Uq7MRabsqYfvL6ZNj/mvBHqn3PE9aHE+lTwD51D3zgCw1RN2sipXsvedwo3g+NynAtS/HIw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "^35.4.0",
-        "@ckeditor/ckeditor5-engine": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-essentials": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-35.4.0.tgz",
-      "integrity": "sha512-tTtTb4NYSQi99LPDzAVUnFhW6iTqSuaylkg0XnDvO2lVR3tAA27gOOjGqc8Ri9NMGGeZkFTvXpnVkXkFnDP2nQ==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-essentials/-/ckeditor5-essentials-44.1.0.tgz",
+      "integrity": "sha512-UWSc2lSCqztfy3LLeuHfyKU/oSbFyw/4KEbQso9DsMPQ4vdmX/sW6BoklCYF9mPJrg+zNSseJj9T/M1Q+Z6U0Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-clipboard": "44.1.0",
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-enter": "44.1.0",
+        "@ckeditor/ckeditor5-select-all": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-undo": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-find-and-replace": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-find-and-replace/-/ckeditor5-find-and-replace-44.1.0.tgz",
+      "integrity": "sha512-SwZYRdXpYCu3t3+k9fxO8JXjNb/Q/OK3nmtVBNly/ZWYmORGQd3ua9XlipcnwIB8aBQqhuV/izDKqSiFZc23zA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-font": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-font/-/ckeditor5-font-44.1.0.tgz",
+      "integrity": "sha512-q4r7I7C2uG9gkBx9WlARNN5ZWp4USHVFS2kLTyMVAN1/iHAKIx03m+N3W0FTZVpXV+xscn7H6KaLcQXmWc4OiQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-heading": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-35.4.0.tgz",
-      "integrity": "sha512-cZwKzAg0USxaDZstQXKMkzrE+fOEr+6YFtXpHGrKgsaisI9xkuOWD40dZvLovTmENLGPopDkdfGewj8jscB9Kg==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-heading/-/ckeditor5-heading-44.1.0.tgz",
+      "integrity": "sha512-cROqN/dnq8xBdxMQoe+1Zjh8bfoVePh6WSl+wjcc4OIozYe/V2QAmCODpYiVm4RntenH0IidHteSTCqtGM4L9w==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-paragraph": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-highlight": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-highlight/-/ckeditor5-highlight-44.1.0.tgz",
+      "integrity": "sha512-bj7DBo1miBf6f7LPLiNa5inziXBKt6dFQupWAgJNJvPxYeGf4jTKDeVc9FLBESJ7eOWKjmCjaNeSsV2smHTAKQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-horizontal-line": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-horizontal-line/-/ckeditor5-horizontal-line-44.1.0.tgz",
+      "integrity": "sha512-xwqQPJQsgwEvbZb3EqjFEcvj1tmlxcX9hFL9I66oGblfYNEIX8Q4DWxbjWCDrfY2IvLO3zNUDI9J5EcxSnd9Pw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-embed": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-embed/-/ckeditor5-html-embed-44.1.0.tgz",
+      "integrity": "sha512-eFXTBHhvRIGflrgpNa2wP0W9IiHx2t2TxQX8881EbF/H3/LDqreyNR7LHBXXgPk1j+H5V/MOGAqG5ntlvq2SdQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-html-support": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-html-support/-/ckeditor5-html-support-44.1.0.tgz",
+      "integrity": "sha512-cBUtojLEreXNYV54B/FT1WBjV+dU5i8vsVKBmYw2QOxmaWl4i/wyEtzPh21Ytcsy2ApmIMT/X27ZppffnKcyGQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-enter": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-image": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-35.4.0.tgz",
-      "integrity": "sha512-SQ+IiIB6SLhdhVy3gRKxxfBXpLikInvaP3ILOvPQlaC0Bt5ciJ3t/180zCBlbCvvRwIQNo4bYbZc5cI8UBIAaA==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-image/-/ckeditor5-image-44.1.0.tgz",
+      "integrity": "sha512-8BbS0y1YSGnQAiA6rTps05DIJ8CcdbGYb+1XFb8QOUCzJenFzNGAe4gnlEPw0zW1C8ZjdahRY1K2Fcb16/q7TQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "^35.4.0",
-        "ckeditor5": "^35.4.0",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-clipboard": "44.1.0",
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-undo": "44.1.0",
+        "@ckeditor/ckeditor5-upload": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-indent": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-35.4.0.tgz",
-      "integrity": "sha512-FNp5S6t/RlY4eARR4E/jzxqjAbsGMa+30ZKS9maTOCx0TDmvmjD0jvZc9+1fe/KzSBk9wtmHYOil1J+W66rKvw==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-indent/-/ckeditor5-indent-44.1.0.tgz",
+      "integrity": "sha512-iFrtDVkXhbHHTJIs+yw0x9X/uEH0kyjQ5pQZM5fAzX6g9TFd71iiJ2l8xBSefXRcqEEPVaMWZgikBeRHmQDyOA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0"
-      },
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-integrations-common": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-integrations-common/-/ckeditor5-integrations-common-2.2.3.tgz",
+      "integrity": "sha512-92kQWQj1wiABF7bY1+J79Ze+WHr7pwVBufn1eeJLWcTXbPQq4sAolfKv8Y8Ka9g69mdyE9+GPWmGFYDeQJVPDg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "ckeditor5": ">=42.0.0 || ^0.0.0-nightly"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-language": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-language/-/ckeditor5-language-44.1.0.tgz",
+      "integrity": "sha512-CudeLs2RvADdchJ6FFznsNrMYHDcOrj8CGuSgyTW9PcsnhAzUOYWuaunJ3xXd8MXwu6pGwEReVYuouc2JQQg6A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-link": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-35.4.0.tgz",
-      "integrity": "sha512-aqHFwlnGyjW/fp/fklD1VupYLsfbvSwsh9RFGIdgJL4TuWnlhxR5JXCOAKyZtvCWpdyuKyqzEB8EV0NQAa+OMg==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-link/-/ckeditor5-link-44.1.0.tgz",
+      "integrity": "sha512-+tDlzrhOrl3TMlj01DsGJwQEsrXZl6A7fD4gFfYS3rO9sgGZSLU+fSxOwWHdQyBp1ujiJGsGFXmKFAUZxs7M/w==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "^35.4.0",
-        "ckeditor5": "^35.4.0",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-clipboard": "44.1.0",
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-list": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-35.4.0.tgz",
-      "integrity": "sha512-fPENWzEicpoXZsDmGR6EiR/j3Z4Q3KYAsBMsmWf8YwUlbM/hERt+V3yIB+LKdGQKbFrL6CWOA1JBB4tmmwd50A==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-list/-/ckeditor5-list-44.1.0.tgz",
+      "integrity": "sha512-lwUAtK68GfNVr1yI+VLom54K8F5bRZee8HKkzFZPgTCANYLUnmHGUNF9La7qETeqjNV6bljUnKwn/knOeserGg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "^35.4.0",
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-clipboard": "44.1.0",
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-enter": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-markdown-gfm": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-markdown-gfm/-/ckeditor5-markdown-gfm-44.1.0.tgz",
+      "integrity": "sha512-ZlFa3xi8vSCCqs4cvfxjZrcXz87i7XIKAd+eTQdwoInQDJHnGpUcM67hKIMSU3E8AjEz+tXdsaauxSofZTS+zQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-clipboard": "44.1.0",
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "marked": "4.0.12",
+        "turndown": "7.2.0",
+        "turndown-plugin-gfm": "1.0.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-media-embed": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-35.4.0.tgz",
-      "integrity": "sha512-So+BYkI82pdIGP2VQ+b+gstEOnHLHA9yBX94pTJM9eW1O+ZTPMR1t2wJFFmEbCjQUYDVC8SdGUGaOb1gaeVXiw==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-media-embed/-/ckeditor5-media-embed-44.1.0.tgz",
+      "integrity": "sha512-ymG55dCUv+i0o0th4+vYMvVHhC2DXTs6J+5t40tNvdMS7apt882Tbq9vAE6iqgQZbtQVVlRpQbGD0UByBO5LVA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-ui": "^35.4.0",
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-clipboard": "44.1.0",
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-undo": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-mention": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-mention/-/ckeditor5-mention-44.1.0.tgz",
+      "integrity": "sha512-LJ2aT5nJ9I8eZT/E/RqD/iPv4fyU8MJqtGQXExEwwAfQDqkx0X5u3mv3uAR/HhyFyj6jFw+z26bTdt13wdSaEw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-minimap": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-minimap/-/ckeditor5-minimap-44.1.0.tgz",
+      "integrity": "sha512-V9xOrUqLxnrOGXOiQVu4QGLV0zam3xMCi+vVR3/jFrVEPRCY1swdC6JhT4PAYt5lPBbrlmyF7u+pZjal8I7F1Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-page-break": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-page-break/-/ckeditor5-page-break-44.1.0.tgz",
+      "integrity": "sha512-6uNuctQnPTr2WFcyKGdTQ/1gTkGmIhiZg8y9UMIY74aEW9AQfGwCaBkAO5AveaBTfmGBkSsAISS3T8k5OGsV0Q==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "ckeditor5": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paragraph": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-35.4.0.tgz",
-      "integrity": "sha512-8nhkEEFv1WClhH6q/HW8P596d+dlatSVc46kQ2+jGlYirL8P66tV/nK+OiE8z1d897oVr4QPGsqk2qGkRFUChw==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paragraph/-/ckeditor5-paragraph-44.1.0.tgz",
+      "integrity": "sha512-tfERMEQRrvM5zdZuiWC5IjCPtUrpncXY4ewn9mcGJ5KqmLaX3e+2dN4GVZpcagwOtZNQNQBONZnuWt9ZVkquFQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "^35.4.0",
-        "@ckeditor/ckeditor5-ui": "^35.4.0",
-        "@ckeditor/ckeditor5-utils": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-paste-from-office": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-35.4.0.tgz",
-      "integrity": "sha512-Uav1z9t52+qcu1axykcZ/NeH7JnURuZF9l0o+Pq/sNg3zjzVqB92V5cvFXg9hXeod8LzxlNLHy1BR8ZWTHeKHQ==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-paste-from-office/-/ckeditor5-paste-from-office-44.1.0.tgz",
+      "integrity": "sha512-NIhtkFoDXNpOaPBDH6dDTU2BC3GUJ1rE5gUV0i4hrtOeERuk9EdkADCOBEHEm7UC31kCQ4si6wkry+d4oZ5FMw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-clipboard": "44.1.0",
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "ckeditor5": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-react": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-react/-/ckeditor5-react-5.1.0.tgz",
-      "integrity": "sha512-7+okLprneCOD/zXceiONstUjRQtMSnsYiW7C2uODgXpglYDANw9QbAoyA4+M0ZC2Sjxok56YPy46F7uXB+a6mA==",
-      "hasInstallScript": true,
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-react/-/ckeditor5-react-9.3.1.tgz",
+      "integrity": "sha512-2lc1ICGCOZ0loC6DeMFwhkhrodLYUsOnC2wdgMiaXnEWRI/fU0SWBAoLbsMH7i6zpq29s+ZWMEImRVbly8SmEA==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
+        "@ckeditor/ckeditor5-integrations-common": "^2.1.0",
         "prop-types": "^15.7.2"
       },
       "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+        "ckeditor5": ">=42.0.0 || ^0.0.0-nightly",
+        "react": "^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-remove-format": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-remove-format/-/ckeditor5-remove-format-44.1.0.tgz",
+      "integrity": "sha512-97ppktKeKIhGYrRKwfzVP0DOktcaY4gFXEtKINmse8kw0C7jO4SE82sDJxWSP/3h74oncZzd/q/Qa6P65JmhWA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-restricted-editing": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-restricted-editing/-/ckeditor5-restricted-editing-44.1.0.tgz",
+      "integrity": "sha512-dsjeug3TCn32idHe4XWaD8ZBtKloAHSDYzv05uEuJDTEkTnSOp8ynVxUCKlTTMeHKjpRPr5kaxJkycqnxOqsvw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-select-all": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-35.4.0.tgz",
-      "integrity": "sha512-c+pIIY77SP6ux4/cyD7cCrllQAqtFVSnzNYdy7ygNPqljCGngCnpSV9xfCO/blFo6/zx2vsmzVGdRq3ArzGoMg==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-select-all/-/ckeditor5-select-all-44.1.0.tgz",
+      "integrity": "sha512-jQH9745sYWpQcZXC4z1lNS4XqrTJWHljWEMa4KKTZgo6zjR/L53tRZdIKbE6O/JgaW805Xpl74cJGXJvwre8VA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "^35.4.0",
-        "@ckeditor/ckeditor5-ui": "^35.4.0",
-        "@ckeditor/ckeditor5-utils": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-show-blocks": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-show-blocks/-/ckeditor5-show-blocks-44.1.0.tgz",
+      "integrity": "sha512-qPjba3VFXgRnnEjlZAfv1XgfC1jNpYUWpfxlniZixvcZ1bEOzEX6rkEqBioNgGFWBU8siPTPiwI2mmT/8/58Vw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-source-editing": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-source-editing/-/ckeditor5-source-editing-44.1.0.tgz",
+      "integrity": "sha512-gg/tWANOiJckvXxKqwthkvR531bPuen+lJN3y2qnqMKMQLLNbWWIUoTuE3PZRHDprT0JmTjnvlHrwsaSdpOkVg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-theme-lark": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-special-characters": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-special-characters/-/ckeditor5-special-characters-44.1.0.tgz",
+      "integrity": "sha512-btw7qEPjrdp/XigtXOXy1KkK481PEeuJ5xdPD2xLlWvZkF0tGbEqIpDIMxkW1w7NmmC+5Aa8qJqXkV6dN4jZ5A==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-style": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-style/-/ckeditor5-style-44.1.0.tgz",
+      "integrity": "sha512-A6udrCj1IxuiPE8OGue/aDtoqs8ZAPsbabnT9OS46WBlDGjXaSStXD7Dx6uJwEkaRdmhdGaObi4UnF7gkHRXHA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-table": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-35.4.0.tgz",
-      "integrity": "sha512-u2g3CIqXO7ByrfFVqlHagPssta8hd/zSE37CjFuylc5KYVmMxcuh3TiFirKaladH92/3gjfnf+GWEC5X14mA8w==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-table/-/ckeditor5-table-44.1.0.tgz",
+      "integrity": "sha512-8iQUW5apSYFrsJhguW0ROPBf+gmKhtP75KIeal6GdEtYlOMA8vP/ixUhQB5HZBmecfAVULyu1fF4YfGzHelZhw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "ckeditor5": "^35.4.0",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-clipboard": "44.1.0",
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-theme-lark": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-theme-lark/-/ckeditor5-theme-lark-44.1.0.tgz",
+      "integrity": "sha512-Ym9ZKtQBqh5xOYGVa+va6CtYJSbhqIfVOsoCRZnMTzg3RTfwp8F78yeWUdplF6DS4JaM966yQumX9DcJGYn5AA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-ui": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-typing": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-35.4.0.tgz",
-      "integrity": "sha512-Ad/PHWbVWcnAj9oevkkfLqf6CmvCFOti466uhvfOCKRNVf2+/xuGwleOGr8W6Lir/x/qav7ojFjKPKDxqbPXhA==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-typing/-/ckeditor5-typing-44.1.0.tgz",
+      "integrity": "sha512-YlIpXSp2mkzgCCwqa4Dd870K4UvKsjlHRDod50G8VSz2qFCkE6PaLGGBAci1IoZ5nBXZMpCrnhrkQ1jAJwx2RA==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "^35.4.0",
-        "@ckeditor/ckeditor5-engine": "^35.4.0",
-        "@ckeditor/ckeditor5-utils": "^35.4.0",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-ui": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-35.4.0.tgz",
-      "integrity": "sha512-0SmYE+k1cYQPqyw2rQsPDV/RpudneBh1bNfiaTOz+rqViJIMe+TxiuK6Fz+znNZ05s0exr+ZHWvMttGqlVoQNw==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-ui/-/ckeditor5-ui-44.1.0.tgz",
+      "integrity": "sha512-Qga/eO6/4rCzK6m/JLMVq0gbgNDEV7K/J+ida1UQFYxrMric7qfriusT1q0Y+6jFYuGMdyLg0e0imORbMyw9Zw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "^35.4.0",
-        "@ckeditor/ckeditor5-utils": "^35.4.0",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "color-convert": "2.0.1",
+        "color-parse": "1.4.2",
+        "lodash-es": "4.17.21",
+        "vanilla-colorful": "0.7.2"
       }
     },
     "node_modules/@ckeditor/ckeditor5-undo": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-35.4.0.tgz",
-      "integrity": "sha512-0RhsK0f/pX/7KB/JXYTLiDOswmUTQ9EKIIuewAwr7LTsBf4Q309FZSFdbeTmc0wIyX33212Xh5xsi3LyG1VJRg==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-undo/-/ckeditor5-undo-44.1.0.tgz",
+      "integrity": "sha512-sULkc7Pvbc431uZCjzcAKd//jYE3B8fT8PEOFG8pYRnQJHc5GyodvH0RmXDhCtKCGtzvh1Dlpb4iSNpPNpVvJQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "^35.4.0",
-        "@ckeditor/ckeditor5-engine": "^35.4.0",
-        "@ckeditor/ckeditor5-ui": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-upload": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-35.4.0.tgz",
-      "integrity": "sha512-+eJAluAc4mAFmx5FNuSGjkCYmbm0V9NpSleubAXEx2e+KNiLarPAnsolwRaAcYXcloNp4C9/l0D+lPEx7VRYtg==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-upload/-/ckeditor5-upload-44.1.0.tgz",
+      "integrity": "sha512-+608NL4Jl6t2PA02Ft8myPV5r2oXwD+4wTCLKg4Oh2KPQYCyGOm5vj8dLxwWNsbMXZrdPxeQOK3UHq8bxYyI6A==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "^35.4.0",
-        "@ckeditor/ckeditor5-ui": "^35.4.0",
-        "@ckeditor/ckeditor5-utils": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0"
       }
     },
     "node_modules/@ckeditor/ckeditor5-utils": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-35.4.0.tgz",
-      "integrity": "sha512-sFjbb+1VYdLbELDLWVYk86WzVN7Lo3sXHbVhdr8+kc0Ufxdr3mTFHDAkiymFt2fs1FOB5gZyWJlJU+EeJnhKUw==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-utils/-/ckeditor5-utils-44.1.0.tgz",
+      "integrity": "sha512-PILjaPvEMuQ0qlnPAFeNTTQcLuXgGionSxaxF8HGnZolaqWnsJ11xGYxqUslNOGtdZNp/88/FC9TjCY/ksiibg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-watchdog": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-watchdog/-/ckeditor5-watchdog-44.1.0.tgz",
+      "integrity": "sha512-fTwYEW1TbbxC7PVmZtfWfwHT5aMREfBTDvH3KQWKpowTcoAiMBlQQKA/lvkRJ1bFMp4AZFjqs1IWZyap/sanAg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@ckeditor/ckeditor5-widget": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-35.4.0.tgz",
-      "integrity": "sha512-SNYOXXWu7XV1BZET+ar0Cea25836vzNtUqXlDPwBx/jrmK86b8GMbFR99P2bUG0NvtIsH5cSk7XCmnxb4ZQ6wA==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-widget/-/ckeditor5-widget-44.1.0.tgz",
+      "integrity": "sha512-dBG1EFJjq38wF0k1p3R2yIfZRHwgY5+hLuF1sp02q/lUJu59U/rPscfjj4dGpE4eKaqCD9z/UNEtOjPGnaJzKw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-core": "^35.4.0",
-        "@ckeditor/ckeditor5-engine": "^35.4.0",
-        "@ckeditor/ckeditor5-enter": "^35.4.0",
-        "@ckeditor/ckeditor5-typing": "^35.4.0",
-        "@ckeditor/ckeditor5-ui": "^35.4.0",
-        "@ckeditor/ckeditor5-utils": "^35.4.0",
-        "lodash-es": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-enter": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@ckeditor/ckeditor5-word-count": {
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/@ckeditor/ckeditor5-word-count/-/ckeditor5-word-count-44.1.0.tgz",
+      "integrity": "sha512-dM8jeZfRA2nodWdE1Ty3ZzaAl3M523ri9/ahLpG/JcCud2QZn9XRPrEwaIxC/1VtZg/Z2SUuI2LcPrbtPkQ0UQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "ckeditor5": "44.1.0",
+        "lodash-es": "4.17.21"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -4012,6 +4351,12 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@mswjs/cookies": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/@mswjs/cookies/-/cookies-0.1.7.tgz",
@@ -4928,130 +5273,79 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sentry-internal/feedback": {
-      "version": "7.120.3",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.120.3.tgz",
-      "integrity": "sha512-ewJJIQ0mbsOX6jfiVFvqMjokxNtgP3dNwUv+4nenN+iJJPQsM6a0ocro3iscxwVdbkjw5hY3BUV2ICI5Q0UWoA==",
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-9.29.0.tgz",
+      "integrity": "sha512-Wp6UJCDVV2KVK+TG8GwdLZyDy4GtUYDmVhGMpHKPS3G/Qgpf36cY/XHwChwaHZ5P9Bk1sjS9Ok698J59S8L2nw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.120.3",
-        "@sentry/types": "7.120.3",
-        "@sentry/utils": "7.120.3"
+        "@sentry/core": "9.29.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-9.29.0.tgz",
+      "integrity": "sha512-ADvetGrtr+RfYcQKrQxah4fHs/xDJ/VjbStVMSuaNllzwWPYNkWIGFE6YjQ7wZszj0DQIu5/H+B6lZKsFYk4xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "9.29.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-9.29.0.tgz",
+      "integrity": "sha512-we/1JPRje8sNowQCyogOV1OYWuDOP/3XmDi48XoFG2HB0XMl2HfL5LI8AvgAvC/5nrqVAAo4ktbjoVLm1fb7rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "9.29.0",
+        "@sentry/core": "9.29.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "7.120.3",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.120.3.tgz",
-      "integrity": "sha512-s5xy+bVL1eDZchM6gmaOiXvTqpAsUfO7122DxVdEDMtwVq3e22bS2aiGa8CUgOiJkulZ+09q73nufM77kOmT/A==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-9.29.0.tgz",
+      "integrity": "sha512-TrQYhSAVPhyenvu0fNkon7BznFibu1mzS5bCudxhgOWajZluUVrXcbp8Q3WZ3R+AogrcgA3Vy6aumP/+fMKdwg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "7.120.3",
-        "@sentry/replay": "7.120.3",
-        "@sentry/types": "7.120.3",
-        "@sentry/utils": "7.120.3"
+        "@sentry-internal/replay": "9.29.0",
+        "@sentry/core": "9.29.0"
       },
       "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@sentry-internal/tracing": {
-      "version": "7.120.3",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.3.tgz",
-      "integrity": "sha512-Ausx+Jw1pAMbIBHStoQ6ZqDZR60PsCByvHdw/jdH9AqPrNE9xlBSf9EwcycvmrzwyKspSLaB52grlje2cRIUMg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.120.3",
-        "@sentry/types": "7.120.3",
-        "@sentry/utils": "7.120.3"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.120.3",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.120.3.tgz",
-      "integrity": "sha512-i9vGcK9N8zZ/JQo1TCEfHHYZ2miidOvgOABRUc9zQKhYdcYQB2/LU1kqlj77Pxdxf4wOa9137d6rPrSn9iiBxg==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-9.29.0.tgz",
+      "integrity": "sha512-+GFX/yb+rh6V1fSgTYM6ttAgledl2aUR3T3Rg86HNuegbdX8ym6lOtUOIZ0j9jPK015HR47KIPyIZVZZJ7Rj9g==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/feedback": "7.120.3",
-        "@sentry-internal/replay-canvas": "7.120.3",
-        "@sentry-internal/tracing": "7.120.3",
-        "@sentry/core": "7.120.3",
-        "@sentry/integrations": "7.120.3",
-        "@sentry/replay": "7.120.3",
-        "@sentry/types": "7.120.3",
-        "@sentry/utils": "7.120.3"
+        "@sentry-internal/browser-utils": "9.29.0",
+        "@sentry-internal/feedback": "9.29.0",
+        "@sentry-internal/replay": "9.29.0",
+        "@sentry-internal/replay-canvas": "9.29.0",
+        "@sentry/core": "9.29.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.120.3",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.3.tgz",
-      "integrity": "sha512-vyy11fCGpkGK3qI5DSXOjgIboBZTriw0YDx/0KyX5CjIjDDNgp5AGgpgFkfZyiYiaU2Ww3iFuKo4wHmBusz1uA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.120.3",
-        "@sentry/utils": "7.120.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/integrations": {
-      "version": "7.120.3",
-      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.3.tgz",
-      "integrity": "sha512-6i/lYp0BubHPDTg91/uxHvNui427df9r17SsIEXa2eKDwQ9gW2qRx5IWgvnxs2GV/GfSbwcx4swUB3RfEWrXrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/core": "7.120.3",
-        "@sentry/types": "7.120.3",
-        "@sentry/utils": "7.120.3",
-        "localforage": "^1.8.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/replay": {
-      "version": "7.120.3",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.120.3.tgz",
-      "integrity": "sha512-CjVq1fP6bpDiX8VQxudD5MPWwatfXk8EJ2jQhJTcWu/4bCSOQmHxnnmBM+GVn5acKUBCodWHBN+IUZgnJheZSg==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry-internal/tracing": "7.120.3",
-        "@sentry/core": "7.120.3",
-        "@sentry/types": "7.120.3",
-        "@sentry/utils": "7.120.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@sentry/types": {
-      "version": "7.120.3",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.3.tgz",
-      "integrity": "sha512-C4z+3kGWNFJ303FC+FxAd4KkHvxpNFYAFN8iMIgBwJdpIl25KZ8Q/VdGn0MLLUEHNLvjob0+wvwlcRBBNLXOow==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.29.0.tgz",
+      "integrity": "sha512-wDyNe45PM+RCGtUn1tK7LzJ08ksv8i8KRUHrst7lsinEfRm83YH+wbWrPmwkVNEngUZvYkHwGLbNXM7xgFUuDQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@sentry/utils": {
-      "version": "7.120.3",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.3.tgz",
-      "integrity": "sha512-UDAOQJtJDxZHQ5Nm1olycBIsz2wdGX8SdzyGVHmD8EOQYAeDZQyIlQYohDe9nazdIOQLZCIc3fU0G9gqVLkaGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@sentry/types": "7.120.3"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=18"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -6793,9 +7087,9 @@
       }
     },
     "node_modules/antd": {
-      "version": "5.25.4",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-5.25.4.tgz",
-      "integrity": "sha512-yXdWqq1NJSZnD1HoPZWnWuQJGVYYnB3h0Ufsz4sbt3T0N9SdJ4G9GPpLMk8Gn9zWtwBekfR4THPVZ9uzAyhBHQ==",
+      "version": "5.26.1",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-5.26.1.tgz",
+      "integrity": "sha512-CiLGZ2Ftld+fuoj+U3OL8uouuqUppqFJnW4O/4bOgSWzM9XsJGibpNtUa9QArhrZ5ndfnzlPP/4RVXUK/xfSvQ==",
       "license": "MIT",
       "dependencies": {
         "@ant-design/colors": "^7.2.1",
@@ -6837,7 +7131,7 @@
         "rc-slider": "~11.1.8",
         "rc-steps": "~6.0.1",
         "rc-switch": "~4.1.0",
-        "rc-table": "~7.50.5",
+        "rc-table": "~7.51.0",
         "rc-tabs": "~15.6.1",
         "rc-textarea": "~1.10.0",
         "rc-tooltip": "~6.4.0",
@@ -7364,6 +7658,12 @@
         "readable-stream": "^3.4.0"
       }
     },
+    "node_modules/blurhash": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/blurhash/-/blurhash-2.0.5.tgz",
+      "integrity": "sha512-cRygWd7kGBQO3VEhPiTgq4Wc43ctsM+o46urrmPOiuAe+07fzlSB9OJVdpgDL0jPqXUVQ9ht7aq7kxOeJHRK+w==",
+      "license": "MIT"
+    },
     "node_modules/bootstrap": {
       "version": "5.3.6",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
@@ -7843,27 +8143,69 @@
       "license": "MIT"
     },
     "node_modules/ckeditor5": {
-      "version": "35.4.0",
-      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-35.4.0.tgz",
-      "integrity": "sha512-vBEQVkFCbjYmEPVkyWsOqU44DOovUio6xBuCwroe4TuJLplqeRasCjFwB0DPknXQU8U0iM3Lh/QSKRyN92pw3Q==",
-      "license": "GPL-2.0-or-later",
+      "version": "44.1.0",
+      "resolved": "https://registry.npmjs.org/ckeditor5/-/ckeditor5-44.1.0.tgz",
+      "integrity": "sha512-6e1KFUE2giaSI0ZOKfAAFF5Tk7PF5DCyKVROPY9/46tti9AZpUFUzr7NhBsZjyMiMX1eqxqfsSZT7f9tKgcVAQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@ckeditor/ckeditor5-clipboard": "^35.4.0",
-        "@ckeditor/ckeditor5-core": "^35.4.0",
-        "@ckeditor/ckeditor5-engine": "^35.4.0",
-        "@ckeditor/ckeditor5-enter": "^35.4.0",
-        "@ckeditor/ckeditor5-paragraph": "^35.4.0",
-        "@ckeditor/ckeditor5-select-all": "^35.4.0",
-        "@ckeditor/ckeditor5-typing": "^35.4.0",
-        "@ckeditor/ckeditor5-ui": "^35.4.0",
-        "@ckeditor/ckeditor5-undo": "^35.4.0",
-        "@ckeditor/ckeditor5-upload": "^35.4.0",
-        "@ckeditor/ckeditor5-utils": "^35.4.0",
-        "@ckeditor/ckeditor5-widget": "^35.4.0"
-      },
-      "engines": {
-        "node": ">=14.0.0",
-        "npm": ">=5.7.1"
+        "@ckeditor/ckeditor5-adapter-ckfinder": "44.1.0",
+        "@ckeditor/ckeditor5-alignment": "44.1.0",
+        "@ckeditor/ckeditor5-autoformat": "44.1.0",
+        "@ckeditor/ckeditor5-autosave": "44.1.0",
+        "@ckeditor/ckeditor5-basic-styles": "44.1.0",
+        "@ckeditor/ckeditor5-block-quote": "44.1.0",
+        "@ckeditor/ckeditor5-bookmark": "44.1.0",
+        "@ckeditor/ckeditor5-ckbox": "44.1.0",
+        "@ckeditor/ckeditor5-ckfinder": "44.1.0",
+        "@ckeditor/ckeditor5-clipboard": "44.1.0",
+        "@ckeditor/ckeditor5-cloud-services": "44.1.0",
+        "@ckeditor/ckeditor5-code-block": "44.1.0",
+        "@ckeditor/ckeditor5-core": "44.1.0",
+        "@ckeditor/ckeditor5-easy-image": "44.1.0",
+        "@ckeditor/ckeditor5-editor-balloon": "44.1.0",
+        "@ckeditor/ckeditor5-editor-classic": "44.1.0",
+        "@ckeditor/ckeditor5-editor-decoupled": "44.1.0",
+        "@ckeditor/ckeditor5-editor-inline": "44.1.0",
+        "@ckeditor/ckeditor5-editor-multi-root": "44.1.0",
+        "@ckeditor/ckeditor5-engine": "44.1.0",
+        "@ckeditor/ckeditor5-enter": "44.1.0",
+        "@ckeditor/ckeditor5-essentials": "44.1.0",
+        "@ckeditor/ckeditor5-find-and-replace": "44.1.0",
+        "@ckeditor/ckeditor5-font": "44.1.0",
+        "@ckeditor/ckeditor5-heading": "44.1.0",
+        "@ckeditor/ckeditor5-highlight": "44.1.0",
+        "@ckeditor/ckeditor5-horizontal-line": "44.1.0",
+        "@ckeditor/ckeditor5-html-embed": "44.1.0",
+        "@ckeditor/ckeditor5-html-support": "44.1.0",
+        "@ckeditor/ckeditor5-image": "44.1.0",
+        "@ckeditor/ckeditor5-indent": "44.1.0",
+        "@ckeditor/ckeditor5-language": "44.1.0",
+        "@ckeditor/ckeditor5-link": "44.1.0",
+        "@ckeditor/ckeditor5-list": "44.1.0",
+        "@ckeditor/ckeditor5-markdown-gfm": "44.1.0",
+        "@ckeditor/ckeditor5-media-embed": "44.1.0",
+        "@ckeditor/ckeditor5-mention": "44.1.0",
+        "@ckeditor/ckeditor5-minimap": "44.1.0",
+        "@ckeditor/ckeditor5-page-break": "44.1.0",
+        "@ckeditor/ckeditor5-paragraph": "44.1.0",
+        "@ckeditor/ckeditor5-paste-from-office": "44.1.0",
+        "@ckeditor/ckeditor5-remove-format": "44.1.0",
+        "@ckeditor/ckeditor5-restricted-editing": "44.1.0",
+        "@ckeditor/ckeditor5-select-all": "44.1.0",
+        "@ckeditor/ckeditor5-show-blocks": "44.1.0",
+        "@ckeditor/ckeditor5-source-editing": "44.1.0",
+        "@ckeditor/ckeditor5-special-characters": "44.1.0",
+        "@ckeditor/ckeditor5-style": "44.1.0",
+        "@ckeditor/ckeditor5-table": "44.1.0",
+        "@ckeditor/ckeditor5-theme-lark": "44.1.0",
+        "@ckeditor/ckeditor5-typing": "44.1.0",
+        "@ckeditor/ckeditor5-ui": "44.1.0",
+        "@ckeditor/ckeditor5-undo": "44.1.0",
+        "@ckeditor/ckeditor5-upload": "44.1.0",
+        "@ckeditor/ckeditor5-utils": "44.1.0",
+        "@ckeditor/ckeditor5-watchdog": "44.1.0",
+        "@ckeditor/ckeditor5-widget": "44.1.0",
+        "@ckeditor/ckeditor5-word-count": "44.1.0"
       }
     },
     "node_modules/classnames": {
@@ -8062,6 +8404,15 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-parse": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.2.tgz",
+      "integrity": "sha512-RI7s49/8yqDj3fECFZjUI1Yi0z/Gq1py43oNJivAIIDSyJiOZLfYCRQEgn8HEVAj++PcRe8AnL2XF0fRJ3BTnA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0"
+      }
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -11026,12 +11377,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
-      "license": "MIT"
-    },
     "node_modules/immutable": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
@@ -13297,15 +13642,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/lie": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
-      "license": "MIT",
-      "dependencies": {
-        "immediate": "~3.0.5"
-      }
-    },
     "node_modules/lilconfig": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
@@ -13467,15 +13803,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/localforage": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
-      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -13749,6 +14076,18 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/math-intrinsics": {
@@ -15557,9 +15896,9 @@
       }
     },
     "node_modules/rc-table": {
-      "version": "7.50.5",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.50.5.tgz",
-      "integrity": "sha512-FDZu8aolhSYd3v9KOc3lZOVAU77wmRRu44R0Wfb8Oj1dXRUsloFaXMSl6f7yuWZUxArJTli7k8TEOX2mvhDl4A==",
+      "version": "7.51.0",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.51.0.tgz",
+      "integrity": "sha512-7ZlvW6lB0IDKaSFInD6OfJsCepSJJtfsQv2PZLtzEeZd/PLzQnKliXPaoZqkqDdLdJ3jxE2x4sane4DjxcAg+g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.10.1",
@@ -17785,6 +18124,21 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/turndown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
+    },
+    "node_modules/turndown-plugin-gfm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
+      "integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
+      "license": "MIT"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -18205,6 +18559,12 @@
       "engines": {
         "node": ">=10.12.0"
       }
+    },
+    "node_modules/vanilla-colorful": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/vanilla-colorful/-/vanilla-colorful-0.7.2.tgz",
+      "integrity": "sha512-z2YZusTFC6KnLERx1cgoIRX2CjPRP0W75N+3CC6gbvdX5Ch47rZkEMGO2Xnf+IEmi3RiFLxS18gayMA27iU7Kg==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.3.5",

--- a/package.json
+++ b/package.json
@@ -78,10 +78,10 @@
     "jest-watch-typeahead": "2.2.2"
   },
   "dependencies": {
-    "@ckeditor/ckeditor5-build-classic": "^35.4.0",
-    "@ckeditor/ckeditor5-react": "^5.0.6",
+    "@ckeditor/ckeditor5-build-classic": "^44.1.0",
+    "@ckeditor/ckeditor5-react": "^9.3.1",
     "@khanacademy/react-multi-select": "^0.3.3",
-    "@sentry/browser": "^7.42.0",
+    "@sentry/browser": "^9.29.0",
     "@types/jest": "^29.5.4",
     "@types/node": "^22.15.19",
     "@types/react": "^18.3.21",
@@ -89,7 +89,7 @@
     "@typescript-eslint/typescript-estree": "^6.5.0",
     "ajv": "^8.17.1",
     "ajv-keywords": "^5.1.0",
-    "antd": "^5.22.4",
+    "antd": "^5.26.1",
     "axios": "^1.6.2",
     "axios-mock-adapter": "^1.21.1",
     "bootstrap": "^5.3.2",


### PR DESCRIPTION
Upgrade realizado nas seguintes bibliotecas:

- @ckeditor/ckeditor5-build-classic: 35.4.0 → 44.1.0
- @ckeditor/ckeditor5-react: 5.1.0 → 9.3.1
- @sentry/browser: 7.42.0 → 9.29.0
- antd: 5.22.4 → 5.26.1
- ajv: Não possui upgrade a ser realizado, permaneceu na mesma versão.

Testes Realizados:

- Páginas com CKEditor: editor carregando, digitação e salvamento funcionando.
- Componentes do Ant Design: botões, modais, tabelas e formulários sem quebras.
- Sistema navegado sem erros no console relacionados ao Sentry.

Nenhuma quebra identificada nos testes manuais.