### PR TITLE
fix: corrige envio de período de recreio nas férias para backend

### DIFF
--- a/src/components/screens/DietaEspecial/Escola/index.jsx
+++ b/src/components/screens/DietaEspecial/Escola/index.jsx
@@ -700,6 +700,9 @@ class solicitacaoDietaEspecial extends Component {
                                 return undefined;
                               },
                             ]}
+                            inputOnChange={(value) => {
+                              this.props.change("periodo_recreio_fim", value);
+                            }}
                             required
                             showMonthDropdown
                             showYearDropdown


### PR DESCRIPTION
Este PR corrige a submissão dos campos de período (periodo_recreio_inicio e periodo_recreio_fim) quando o campo "Dieta para Recreio nas Férias" está selecionado na tela de Nova Solicitação de Dieta Especial para Aluno Não Matriculado.

Favor revisar.