### PR TITLE
Feature/130730 testes cadastro tipo alimentacao

### DIFF
--- a/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/components/modal_exclui_combo_substituicoes.test.jsx
+++ b/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/components/modal_exclui_combo_substituicoes.test.jsx
@@ -1,0 +1,76 @@
+import {
+  render,
+  screen,
+  act,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL } from "src/constants/shared";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import ModalExcluirComboSubstituicoes from "../../components/ModalExcluirComboSubstituicoes";
+
+describe("Verifica os comportamento do componente de exclusão de combo de substituições", () => {
+  const closeModal = jest.fn();
+  const deletaComboSubstituicao = jest.fn();
+  beforeEach(async () => {
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <ModalExcluirComboSubstituicoes
+              showModal={true}
+              closeModal={closeModal}
+              deletaComboSubstituicao={deletaComboSubstituicao}
+              combo={{
+                label: "teste",
+              }}
+              indice={1}
+            />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  it("Verifica se o componente foi renderizado", () => {
+    expect(
+      screen.getByText(/tem certeza que deseja excluir essa combinação/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/confirmar/i)).toBeInTheDocument();
+    expect(screen.getByText(/cancelar/i)).toBeInTheDocument();
+  });
+
+  it("Seleciona botão confirmar e verifica se funções foram chamadas.", async () => {
+    const botaoConfirmar = screen.getByText(/confirmar/i).closest("button");
+    fireEvent.click(botaoConfirmar);
+    await waitFor(() => {
+      expect(deletaComboSubstituicao).toHaveBeenCalled();
+      expect(closeModal).toHaveBeenCalled();
+    });
+  });
+
+  it("Seleciona botão cancelar e verifica se closeModal foi chamado.", async () => {
+    const botaoConfirmar = screen.getByText(/cancelar/i).closest("button");
+    fireEvent.click(botaoConfirmar);
+    await waitFor(() => {
+      expect(closeModal).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/components/modal_excluir_combo_tipo_alimentacao.test.jsx
+++ b/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/components/modal_excluir_combo_tipo_alimentacao.test.jsx
@@ -1,0 +1,76 @@
+import {
+  render,
+  screen,
+  act,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL } from "src/constants/shared";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import ModalExcluirComboTipoAlimentacao from "../../components/ModalExcluirComboTipoAlimentacao";
+
+describe("Verifica os comportamento do componente de exclusão de combo de tipo de alimentação", () => {
+  const closeModal = jest.fn();
+  const deletaComboTipoAlimentacao = jest.fn();
+  beforeEach(async () => {
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <ModalExcluirComboTipoAlimentacao
+              showModal={true}
+              closeModal={closeModal}
+              deletaComboTipoAlimentacao={deletaComboTipoAlimentacao}
+              combo={{
+                label: "teste",
+              }}
+              indice={1}
+            />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  it("Verifica se o componente foi renderizado", () => {
+    expect(
+      screen.getByText(/Tem certeza que deseja excluir essa combinação/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/confirmar/i)).toBeInTheDocument();
+    expect(screen.getByText(/cancelar/i)).toBeInTheDocument();
+  });
+
+  it("Seleciona botão confirmar e verifica se funções foram chamadas.", async () => {
+    const botaoConfirmar = screen.getByText(/confirmar/i).closest("button");
+    fireEvent.click(botaoConfirmar);
+    await waitFor(() => {
+      expect(deletaComboTipoAlimentacao).toHaveBeenCalled();
+      expect(closeModal).toHaveBeenCalled();
+    });
+  });
+
+  it("Seleciona botão cancelar e verifica se closeModal foi chamado.", async () => {
+    const botaoConfirmar = screen.getByText(/cancelar/i).closest("button");
+    fireEvent.click(botaoConfirmar);
+    await waitFor(() => {
+      expect(closeModal).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/erros/formulario_erro_editar_tipo_alimentacao.test.jsx
+++ b/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/erros/formulario_erro_editar_tipo_alimentacao.test.jsx
@@ -1,0 +1,105 @@
+import {
+  render,
+  screen,
+  act,
+  waitFor,
+  fireEvent,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL } from "src/constants/shared";
+import mock from "src/services/_mock";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import { mockGetTiposUnidadeEscolar } from "src/mocks/cadastroTipoAlimentacao.service/mockGetTiposUnidadeEscolar";
+import { mockGetTipoAlimentacao } from "src/mocks/cadastroTipoAlimentacao.service/mockGetTipoAlimentacao";
+import { mockGetVinculosTipoAlimentacaoPorEscola } from "src/mocks/cadastroTipoAlimentacao.service/mockGetVinculosTipoAlimentacaoPorEscola";
+import { ToastContainer } from "react-toastify";
+import Container from "../../Container";
+
+describe("Verifica comportamento do formulário de cadastro de tipo de alimentação ao receber erro", () => {
+  let fetchSpy;
+  beforeEach(async () => {
+    mock.onGet("/tipos-alimentacao/").reply(200, mockGetTipoAlimentacao);
+    mock
+      .onGet("/tipos-unidade-escolar/")
+      .reply(200, mockGetTiposUnidadeEscolar);
+    fetchSpy = jest.spyOn(window, "fetch").mockImplementation(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            count: 3,
+            next: null,
+            previous: null,
+            results: mockGetVinculosTipoAlimentacaoPorEscola.results.filter(
+              (e) => e.tipo_unidade_escolar.iniciais === "CCI"
+            ),
+          }),
+        ok: true,
+        status: 200,
+      })
+    );
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <ToastContainer />
+            <Container />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  const selecionaTipoUnidade = () => {
+    const caretIcon = screen.getByLabelText(/caret-down/i);
+    fireEvent.click(caretIcon);
+    const opcao = screen.getByText("CCI");
+    expect(opcao).toBeInTheDocument();
+    fireEvent.click(opcao);
+  };
+
+  it("Envia atualização de vinculo e recebe retorno de erro do backend", async () => {
+    mock
+      .onPut(
+        "/vinculos-tipo-alimentacao-u-e-periodo-escolar/atualizar_lista_de_vinculos/"
+      )
+      .reply(400, {});
+    selecionaTipoUnidade();
+
+    await waitFor(() => {
+      const opcao = screen.getAllByRole("checkbox", { name: /lanche 4h/i })[0];
+      expect(opcao).toBeInTheDocument();
+      fireEvent.click(opcao);
+      expect(opcao).toBeChecked();
+    });
+
+    const botaoSalvar = screen.getAllByText(/salvar/i)[0].closest("button");
+    expect(botaoSalvar).toBeEnabled();
+    fireEvent.click(botaoSalvar);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/erro ao atualizar tipos de alimentação/i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/erros/formulario_erro_periodo_escolar_ausente.test.jsx
+++ b/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/erros/formulario_erro_periodo_escolar_ausente.test.jsx
@@ -1,0 +1,87 @@
+import {
+  render,
+  screen,
+  act,
+  waitFor,
+  fireEvent,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL } from "src/constants/shared";
+import mock from "src/services/_mock";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import { mockGetTiposUnidadeEscolar } from "src/mocks/cadastroTipoAlimentacao.service/mockGetTiposUnidadeEscolar";
+import { mockGetTipoAlimentacao } from "src/mocks/cadastroTipoAlimentacao.service/mockGetTipoAlimentacao";
+import { ToastContainer } from "react-toastify";
+import Container from "../../Container";
+
+describe("Verifica comportamento do formulário de cadastro de tipo de alimentação ao não receber períodos escolar", () => {
+  let fetchSpy;
+  beforeEach(async () => {
+    mock.onGet("/tipos-alimentacao/").reply(200, mockGetTipoAlimentacao);
+    mock
+      .onGet("/tipos-unidade-escolar/")
+      .reply(200, mockGetTiposUnidadeEscolar);
+    fetchSpy = jest.spyOn(window, "fetch").mockImplementation(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            count: 0,
+            next: null,
+            previous: null,
+            results: [],
+          }),
+        ok: true,
+        status: 200,
+      })
+    );
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <ToastContainer />
+            <Container />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  const selecionaTipoUnidade = () => {
+    const caretIcon = screen.getByLabelText(/caret-down/i);
+    fireEvent.click(caretIcon);
+    const opcao = screen.getByText("CCI");
+    expect(opcao).toBeInTheDocument();
+    fireEvent.click(opcao);
+  };
+
+  it("Não recebe períodos e retorna o aviso de que nenhum está associado ao tipo de unidade escolar selecionado", async () => {
+    selecionaTipoUnidade();
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /nenhum período escolar está associado ao tipo de unidade escolar selecionado/i
+        )
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/formulario_tipo_alimentacao.test.jsx
+++ b/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/formulario_tipo_alimentacao.test.jsx
@@ -1,0 +1,124 @@
+import {
+  render,
+  screen,
+  act,
+  waitFor,
+  fireEvent,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL } from "src/constants/shared";
+import mock from "src/services/_mock";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import { mockGetTiposUnidadeEscolar } from "src/mocks/cadastroTipoAlimentacao.service/mockGetTiposUnidadeEscolar";
+import { mockGetTipoAlimentacao } from "src/mocks/cadastroTipoAlimentacao.service/mockGetTipoAlimentacao";
+import { mockGetVinculosTipoAlimentacaoPorEscola } from "src/mocks/cadastroTipoAlimentacao.service/mockGetVinculosTipoAlimentacaoPorEscola";
+import Container from "../Container";
+import { ToastContainer } from "react-toastify";
+
+describe("Verifica os comportamentos do formulário de cadastro de tipo de alimentação", () => {
+  let fetchSpy;
+  beforeEach(async () => {
+    mock.onGet("/tipos-alimentacao/").reply(200, mockGetTipoAlimentacao);
+    mock
+      .onGet("/tipos-unidade-escolar/")
+      .reply(200, mockGetTiposUnidadeEscolar);
+    fetchSpy = jest.spyOn(window, "fetch").mockImplementation(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            count: 3,
+            next: null,
+            previous: null,
+            results: mockGetVinculosTipoAlimentacaoPorEscola.results.filter(
+              (e) => e.tipo_unidade_escolar.iniciais === "CCI"
+            ),
+          }),
+        ok: true,
+        status: 200,
+      })
+    );
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <ToastContainer />
+            <Container />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("Verifica se a interface foi renderizada", () => {
+    expect(screen.getByText(/tipos de unidades/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/permissão de lançamentos especiais/i)
+    ).toBeInTheDocument();
+  });
+
+  const selecionaTipoUnidade = () => {
+    const caretIcon = screen.getByLabelText(/caret-down/i);
+    fireEvent.click(caretIcon);
+    const opcao = screen.getByText("CCI");
+    expect(opcao).toBeInTheDocument();
+    fireEvent.click(opcao);
+  };
+
+  it("Seleciona uma opção de tipo de alimentação e verifica a exibição", async () => {
+    selecionaTipoUnidade();
+    await waitFor(() => {
+      expect(
+        screen.getByText("Períodos e Tipos de Refeição")
+      ).toBeInTheDocument();
+      expect(screen.getByText("INTEGRAL")).toBeInTheDocument();
+      expect(screen.getByText("MANHA")).toBeInTheDocument();
+      expect(screen.getByText("TARDE")).toBeInTheDocument();
+    });
+  });
+
+  it("Seleciona uma opção, altera a alimentação e realiza o salvamento", async () => {
+    mock
+      .onPut(
+        "/vinculos-tipo-alimentacao-u-e-periodo-escolar/atualizar_lista_de_vinculos/"
+      )
+      .reply(200, {});
+    selecionaTipoUnidade();
+
+    await waitFor(() => {
+      const opcao = screen.getAllByRole("checkbox", { name: /lanche 4h/i })[0];
+      expect(opcao).toBeInTheDocument();
+      fireEvent.click(opcao);
+      expect(opcao).toBeChecked();
+    });
+
+    const botaoSalvar = screen.getAllByText(/salvar/i)[0].closest("button");
+    expect(botaoSalvar).toBeEnabled();
+    fireEvent.click(botaoSalvar);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/tipo de alimentação salvo com sucesso/i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/mocks/cadastroTipoAlimentacao.service/mockGetTipoAlimentacao.jsx
+++ b/src/mocks/cadastroTipoAlimentacao.service/mockGetTipoAlimentacao.jsx
@@ -1,0 +1,52 @@
+export const mockGetTipoAlimentacao = {
+  count: 9,
+  next: null,
+  previous: null,
+  results: [
+    {
+      nome: "Lanche 4h",
+      uuid: "83fefd96-e476-42a0-81fc-75b9853b726c",
+      posicao: 1,
+    },
+    {
+      nome: "Lanche",
+      uuid: "5d1304c8-77a8-4c96-badb-dd2e8c1b76d5",
+      posicao: 2,
+    },
+    {
+      nome: "Refeição",
+      uuid: "65f11f11-630b-4629-bb17-07c875c548f1",
+      posicao: 3,
+    },
+    {
+      nome: "Sobremesa",
+      uuid: "5aa2c32b-1df2-46b6-b2e7-514b885fa9a4",
+      posicao: 4,
+    },
+    {
+      nome: "Refeição da tarde",
+      uuid: "5bd9ad5c-e0ab-4812-b2b6-336fc89886b1",
+      posicao: null,
+    },
+    {
+      nome: "Lanche Emergencial",
+      uuid: "c4255a14-85fd-412f-b35f-30828215e4d5",
+      posicao: null,
+    },
+    {
+      nome: "Colação",
+      uuid: "8e0917e0-70d0-41a8-a5bb-f85bbdd790bb",
+      posicao: null,
+    },
+    {
+      nome: "Almoço",
+      uuid: "7990ca99-55b7-4fc7-b5cc-8a51b23d0102",
+      posicao: null,
+    },
+    {
+      nome: "Desjejum",
+      uuid: "96cad31e-acb8-4dc3-8861-df0731b375ea",
+      posicao: null,
+    },
+  ],
+};

--- a/src/mocks/cadastroTipoAlimentacao.service/mockGetTiposUnidadeEscolar.jsx
+++ b/src/mocks/cadastroTipoAlimentacao.service/mockGetTiposUnidadeEscolar.jsx
@@ -4,6 +4,56 @@ export const mockGetTiposUnidadeEscolar = {
   previous: null,
   results: [
     {
+      periodos_escolares: [
+        {
+          uuid: "e17e2405-36be-4981-a09c-35c89ae0f8b7",
+          nome: "INTEGRAL",
+          tipos_alimentacao: [
+            {
+              uuid: "5d1304c8-77a8-4c96-badb-dd2e8c1b76d5",
+              nome: "Lanche",
+            },
+            {
+              uuid: "65f11f11-630b-4629-bb17-07c875c548f1",
+              nome: "Refeição",
+            },
+            {
+              uuid: "5aa2c32b-1df2-46b6-b2e7-514b885fa9a4",
+              nome: "Sobremesa",
+            },
+            {
+              uuid: "7990ca99-55b7-4fc7-b5cc-8a51b23d0102",
+              nome: "Almoço",
+            },
+            {
+              uuid: "8e0917e0-70d0-41a8-a5bb-f85bbdd790bb",
+              nome: "Colação",
+            },
+            {
+              uuid: "5bd9ad5c-e0ab-4812-b2b6-336fc89886b1",
+              nome: "Refeição da tarde",
+            },
+            {
+              uuid: "c4255a14-85fd-412f-b35f-30828215e4d5",
+              nome: "Lanche Emergencial",
+            },
+            {
+              uuid: "96cad31e-acb8-4dc3-8861-df0731b375ea",
+              nome: "Desjejum",
+            },
+          ],
+          posicao: 1,
+          tipo_turno: 6,
+          possui_alunos_regulares: null,
+        },
+      ],
+      iniciais: "CCI",
+      ativo: true,
+      uuid: "de8dab55-687f-46ce-8cf2-21381ccd6629",
+      tem_somente_integral_e_parcial: true,
+      pertence_relatorio_solicitacoes_alimentacao: false,
+    },
+    {
       periodos_escolares: [],
       iniciais: "CCI/CIPS",
       ativo: true,

--- a/src/mocks/cadastroTipoAlimentacao.service/mockGetVinculosTipoAlimentacaoPorEscola.jsx
+++ b/src/mocks/cadastroTipoAlimentacao.service/mockGetVinculosTipoAlimentacaoPorEscola.jsx
@@ -1,8 +1,78 @@
 export const mockGetVinculosTipoAlimentacaoPorEscola = {
-  count: 6,
+  count: 9,
   next: null,
   previous: null,
   results: [
+    {
+      uuid: "1f7f5d33-8423-4a80-a1ae-ff8f9074068b",
+      tipo_unidade_escolar: {
+        iniciais: "CCI",
+        ativo: true,
+        uuid: "de8dab55-687f-46ce-8cf2-21381ccd6629",
+        tem_somente_integral_e_parcial: true,
+        pertence_relatorio_solicitacoes_alimentacao: false,
+      },
+      periodo_escolar: {
+        possui_alunos_regulares: null,
+        nome: "INTEGRAL",
+        uuid: "e17e2405-36be-4981-a09c-35c89ae0f8b7",
+        posicao: 1,
+        tipo_turno: 6,
+      },
+      tipos_alimentacao: [
+        {
+          nome: "Lanche",
+          uuid: "5d1304c8-77a8-4c96-badb-dd2e8c1b76d5",
+          posicao: 2,
+        },
+        {
+          nome: "Refeição da tarde",
+          uuid: "5bd9ad5c-e0ab-4812-b2b6-336fc89886b1",
+          posicao: null,
+        },
+        {
+          nome: "Almoço",
+          uuid: "7990ca99-55b7-4fc7-b5cc-8a51b23d0102",
+          posicao: null,
+        },
+      ],
+    },
+    {
+      uuid: "0b408b7a-8ca4-4ff1-a16d-9a572bb09b71",
+      tipo_unidade_escolar: {
+        iniciais: "CCI",
+        ativo: true,
+        uuid: "de8dab55-687f-46ce-8cf2-21381ccd6629",
+        tem_somente_integral_e_parcial: true,
+        pertence_relatorio_solicitacoes_alimentacao: false,
+      },
+      periodo_escolar: {
+        possui_alunos_regulares: null,
+        nome: "MANHA",
+        uuid: "5067e137-e5f3-4876-a63f-7f58cce93f33",
+        posicao: 2,
+        tipo_turno: 1,
+      },
+      tipos_alimentacao: [],
+    },
+    {
+      uuid: "fca8cb92-5f9d-4668-b8ee-9784a2d60a9d",
+      tipo_unidade_escolar: {
+        iniciais: "CCI",
+        ativo: true,
+        uuid: "de8dab55-687f-46ce-8cf2-21381ccd6629",
+        tem_somente_integral_e_parcial: true,
+        pertence_relatorio_solicitacoes_alimentacao: false,
+      },
+      periodo_escolar: {
+        possui_alunos_regulares: null,
+        nome: "TARDE",
+        uuid: "20bd9ca9-d499-456a-bd86-fb8f297947d6",
+        posicao: 3,
+        tipo_turno: 3,
+      },
+      tipos_alimentacao: [],
+    },
     {
       uuid: "cdb15dfd-31df-4f7d-ab62-e419f9c5e183",
       tipo_unidade_escolar: {


### PR DESCRIPTION
Este Pull Request:

Implementa testes na interface de cadastro tipos de alimentação:

- Testes no formulário de dados de tipo de alimentação por unidade escolar

- Testes no formulário de dados de tipo de alimentação em caso de erro ou ausência de informação
- Testes no modal de exclusão combo substituições
- Testes no modal de exclusão combo tipo de alimentação

Referência no Azure: [AB#130730](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/130730)