### PR TITLE
Feature/130730 testes cadastro faixas etarias

### DIFF
--- a/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/components/modal_exclui_combo_substituicoes.test.jsx
+++ b/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/components/modal_exclui_combo_substituicoes.test.jsx
@@ -67,8 +67,8 @@ describe("Verifica os comportamento do componente de exclusão de combo de subst
   });
 
   it("Seleciona botão cancelar e verifica se closeModal foi chamado.", async () => {
-    const botaoConfirmar = screen.getByText(/cancelar/i).closest("button");
-    fireEvent.click(botaoConfirmar);
+    const botaoCancelar = screen.getByText(/cancelar/i).closest("button");
+    fireEvent.click(botaoCancelar);
     await waitFor(() => {
       expect(closeModal).toHaveBeenCalled();
     });

--- a/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/components/modal_excluir_combo_tipo_alimentacao.test.jsx
+++ b/src/components/screens/Cadastros/CadastroTipoAlimentacao/__tests__/components/modal_excluir_combo_tipo_alimentacao.test.jsx
@@ -67,8 +67,8 @@ describe("Verifica os comportamento do componente de exclusão de combo de tipo 
   });
 
   it("Seleciona botão cancelar e verifica se closeModal foi chamado.", async () => {
-    const botaoConfirmar = screen.getByText(/cancelar/i).closest("button");
-    fireEvent.click(botaoConfirmar);
+    const botaoCancelar = screen.getByText(/cancelar/i).closest("button");
+    fireEvent.click(botaoCancelar);
     await waitFor(() => {
       expect(closeModal).toHaveBeenCalled();
     });

--- a/src/components/screens/Cadastros/FaixasEtarias/Editar.jsx
+++ b/src/components/screens/Cadastros/FaixasEtarias/Editar.jsx
@@ -65,6 +65,7 @@ const FaixaEtariaItem = ({
 export default class FaixasEtariasEditar extends Component {
   SEIS_ANOS = 6 * 12;
   SEIS_ANOS_MAIS_UM_MES = this.SEIS_ANOS + 1;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -75,6 +76,7 @@ export default class FaixasEtariasEditar extends Component {
     this.cancelarEdicao = this.cancelarEdicao.bind(this);
     this.onFinalizar = this.onFinalizar.bind(this);
   }
+
   selecionaMes(mes) {
     if (isNaN(mes)) return;
     if (this.state.mesEdicaoAtual !== undefined) {
@@ -106,6 +108,7 @@ export default class FaixasEtariasEditar extends Component {
       });
     }
   }
+
   cancelarEdicao() {
     this.setState({
       mesEdicaoAtual: undefined,
@@ -115,6 +118,7 @@ export default class FaixasEtariasEditar extends Component {
       ),
     });
   }
+
   apagarFaixa(indice) {
     const faixasEtarias = this.state.faixasEtarias.filter(
       (f, i) => i !== indice
@@ -124,9 +128,11 @@ export default class FaixasEtariasEditar extends Component {
       meses: mesesForaDasFaixas(faixasEtarias, this.SEIS_ANOS_MAIS_UM_MES),
     });
   }
+
   onFinalizar() {
     this.props.onFinalizar(this.state.faixasEtarias);
   }
+
   render() {
     return (
       <div className="card mt-3 faixas-etarias-editar">
@@ -197,6 +203,7 @@ export default class FaixasEtariasEditar extends Component {
               style={BUTTON_STYLE.GREEN_OUTLINE}
               disabled={this.state.meses.length > 0}
               onClick={this.onFinalizar}
+              dataTestId="finaliza-edicao-faixas-button"
             />
             {this.props.redefinir && (
               <Botao
@@ -205,6 +212,7 @@ export default class FaixasEtariasEditar extends Component {
                 type={BUTTON_TYPE.BUTTON}
                 style={BUTTON_STYLE.GREEN_OUTLINE}
                 onClick={this.props.onCancelar}
+                dataTestId="cancela-edicao-faixas-button"
               />
             )}
           </div>

--- a/src/components/screens/Cadastros/FaixasEtarias/__tests__/editar_faixas_etarias.test.jsx
+++ b/src/components/screens/Cadastros/FaixasEtarias/__tests__/editar_faixas_etarias.test.jsx
@@ -1,0 +1,99 @@
+import {
+  render,
+  screen,
+  act,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL } from "src/constants/shared";
+import mock from "src/services/_mock";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import { mockFaixasEtarias } from "src/mocks/faixaEtaria.service/mockGetFaixasEtarias";
+import FaixasEtariasPage from "src/pages/Cadastros/FaixasEtariasPage";
+
+describe("Verifica os comportamentos do formulário de edição de faixas etárias", () => {
+  beforeEach(async () => {
+    mock.onGet("/faixas-etarias/").reply(200, mockFaixasEtarias);
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <FaixasEtariasPage />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  const iniciaRedefinicao = async () => {
+    const botaoRedefinir = screen.getByText(/redefinir/i).closest("button");
+    fireEvent.click(botaoRedefinir);
+    await waitFor(() => {
+      const botaoContinuar = screen.getByText(/continuar/i).closest("button");
+      fireEvent.click(botaoContinuar);
+    });
+  };
+
+  it("Inicia a redificação das faixas e verifica se a interface foi renderizada", async () => {
+    await iniciaRedefinicao();
+    expect(
+      screen.getByText(/selecione um mês para começar uma faixa/i)
+    ).toBeInTheDocument();
+  });
+
+  it("Inicia a redificação das faixas, faz o preenchimento do formulário e avança", async () => {
+    await iniciaRedefinicao();
+    const botaoRedefinir = screen.getByTestId("cancela-edicao-faixas-button");
+    fireEvent.click(botaoRedefinir);
+    await waitFor(() => {
+      expect(screen.getByText(/resumo do cadastro/i)).toBeInTheDocument();
+    });
+  });
+
+  const selecionaOpcaoFaixa = (valor) => {
+    const opcao = screen.getByText(valor);
+    fireEvent.click(opcao);
+  };
+
+  it("Inicia a redificação das faixas e retorna para tela de resumos", async () => {
+    const opcaoesSelecionaveis = [
+      { primeira: "00 meses", segunda: "01 ano e 02 meses" },
+      { primeira: "01 ano e 03 meses", segunda: "02 anos e 05 meses" },
+      { primeira: "02 anos e 06 meses", segunda: "03 anos e 08 meses" },
+      { primeira: "03 anos e 09 meses", segunda: "04 anos e 11 meses" },
+      { primeira: "05 anos", segunda: "06 anos" },
+    ];
+
+    await iniciaRedefinicao();
+    opcaoesSelecionaveis.forEach(({ primeira, segunda }) => {
+      selecionaOpcaoFaixa(primeira);
+      selecionaOpcaoFaixa(segunda);
+    });
+
+    const botaoFinalizar = screen.getByTestId("finaliza-edicao-faixas-button");
+    fireEvent.click(botaoFinalizar);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/redefinição de novas faixas etárias/i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/screens/Cadastros/FaixasEtarias/__tests__/modal_aviso_redefinicao.test.jsx
+++ b/src/components/screens/Cadastros/FaixasEtarias/__tests__/modal_aviso_redefinicao.test.jsx
@@ -1,0 +1,74 @@
+import {
+  render,
+  screen,
+  act,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL } from "src/constants/shared";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import ModalAvisoRedefinicao from "../ModalAvisoRedefinicao";
+
+describe("Verifica os comportamento do modal de aviso de redefinição de faixas etárias", () => {
+  const closeModal = jest.fn();
+  const onCancelar = jest.fn();
+  beforeEach(async () => {
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <ModalAvisoRedefinicao
+              showModal={true}
+              closeModal={closeModal}
+              onCancelar={onCancelar}
+            />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  it("Verifica se o componente foi renderizado", () => {
+    expect(
+      screen.getByText(
+        /as faixas etárias já cadastradas serão alteradas após a finalização/i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/redefinição de novas faixas etárias/i)
+    ).toBeInTheDocument();
+  });
+
+  it("Seleciona botão confirmar e verifica se funções foram chamadas.", async () => {
+    const botao = screen.getByText(/continuar/i).closest("button");
+    fireEvent.click(botao);
+    await waitFor(() => {
+      expect(closeModal).toHaveBeenCalled();
+    });
+  });
+
+  it("Seleciona botão cancelar e verifica se closeModal foi chamado.", async () => {
+    const botao = screen.getByText(/cancelar/i).closest("button");
+    fireEvent.click(botao);
+    await waitFor(() => {
+      expect(closeModal).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/screens/Cadastros/FaixasEtarias/__tests__/modal_justificativa_redifinicao.test.jsx
+++ b/src/components/screens/Cadastros/FaixasEtarias/__tests__/modal_justificativa_redifinicao.test.jsx
@@ -1,0 +1,91 @@
+import {
+  render,
+  screen,
+  act,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL } from "src/constants/shared";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import ModalJustificativa from "../ModalJustificativa";
+
+jest.mock("src/components/Shareable/CKEditorField", () => ({
+  __esModule: true,
+  default: () => (
+    <textarea
+      data-testid="redefinicao-justificativa-input"
+      name="justificativa"
+      required={true}
+    />
+  ),
+}));
+
+describe("Verifica os comportamento do modal de aviso de redefinição de faixas etárias", () => {
+  const closeModal = jest.fn();
+  const onSubmit = jest.fn();
+  beforeEach(async () => {
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <ModalJustificativa
+              showModal={true}
+              closeModal={closeModal}
+              onSubmit={onSubmit}
+            />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  it("Verifica se o componente foi renderizado", () => {
+    expect(
+      screen.getByText(/redefinição de novas faixas etárias/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/sim/i)).toBeInTheDocument();
+    expect(screen.getByText(/não/i)).toBeInTheDocument();
+  });
+
+  it("Cancela envio da justificativa de redefinição", async () => {
+    const botao = screen.getByText(/não/i).closest("button");
+    fireEvent.click(botao);
+    await waitFor(() => {
+      expect(closeModal).toHaveBeenCalled();
+    });
+  });
+
+  it("Realiza envio da justificativa de redefinição", async () => {
+    const textarea = screen.getByTestId("redefinicao-justificativa-input");
+    fireEvent.change(textarea, {
+      target: { value: "justificativa da alteração" },
+    });
+    await waitFor(() => {
+      expect(textarea.value).toBe("justificativa da alteração");
+    });
+
+    const botao = screen.queryByText(/sim/i).closest("button");
+    fireEvent.click(botao);
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/screens/Cadastros/FaixasEtarias/__tests__/resumo_faixas_etarias.test.jsx
+++ b/src/components/screens/Cadastros/FaixasEtarias/__tests__/resumo_faixas_etarias.test.jsx
@@ -1,0 +1,65 @@
+import {
+  render,
+  screen,
+  act,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL } from "src/constants/shared";
+import mock from "src/services/_mock";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import { mockFaixasEtarias } from "src/mocks/faixaEtaria.service/mockGetFaixasEtarias";
+import FaixasEtariasPage from "src/pages/Cadastros/FaixasEtariasPage";
+
+describe("Verifica os comportamentos da exibição de resumo de faixas etárias", () => {
+  beforeEach(async () => {
+    mock.onGet("/faixas-etarias/").reply(200, mockFaixasEtarias);
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <FaixasEtariasPage />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  it("Verifica se a interface foi renderizada com os dados corretamente", () => {
+    expect(screen.getByText(/resumo do cadastro/i)).toBeInTheDocument();
+    expect(screen.getByText(/tipos de faixas etárias/i)).toBeInTheDocument();
+    expect(screen.getByText(/01 a 03 meses/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/redefinir/i).closest("button")
+    ).toBeInTheDocument();
+  });
+
+  it("Executa ação de 'redefinir' faixas e recebe o modal de confirmação", async () => {
+    const botao = screen.getByText(/redefinir/i).closest("button");
+    fireEvent.click(botao);
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /as faixas etárias já cadastradas serão alteradas após a finalização/i
+        )
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/mocks/faixaEtaria.service/mockGetFaixasEtarias.jsx
+++ b/src/mocks/faixaEtaria.service/mockGetFaixasEtarias.jsx
@@ -1,0 +1,49 @@
+export const mockFaixasEtarias = {
+  count: 7,
+  next: null,
+  previous: null,
+  results: [
+    {
+      __str__: "00 meses",
+      uuid: "1b77202d-fd0b-46b7-b4ec-04eb262efece",
+      inicio: 0,
+      fim: 1,
+    },
+    {
+      __str__: "01 a 03 meses",
+      uuid: "381aecc2-e1b2-4d26-a156-1834eec7f1dd",
+      inicio: 1,
+      fim: 4,
+    },
+    {
+      __str__: "04 a 05 meses",
+      uuid: "4e60c819-4c0b-4d46-95c8-2e3b9674b40e",
+      inicio: 4,
+      fim: 6,
+    },
+    {
+      __str__: "06 meses",
+      uuid: "78e4f4a6-ae04-42a6-9cc3-8f9813e98e66",
+      inicio: 6,
+      fim: 7,
+    },
+    {
+      __str__: "07 a 11 meses",
+      uuid: "55f0af28-e1d5-43a0-a3f3-bbc453b784a5",
+      inicio: 7,
+      fim: 12,
+    },
+    {
+      __str__: "01 ano a 03 anos e 11 meses",
+      uuid: "e3030bd1-2e85-4676-87b3-96b4032370d4",
+      inicio: 12,
+      fim: 48,
+    },
+    {
+      __str__: "04 anos a 06 anos",
+      uuid: "2e14cd6e-33e6-4168-b1ce-449f686d1e7d",
+      inicio: 48,
+      fim: 73,
+    },
+  ],
+};


### PR DESCRIPTION
Este Pull Request:

Implementa testes na interface de cadastro de faixas etárias:

- Testes na exibição de resumo de faixas etárias

- Testes no formulário de edição faixas etárias

- Testes no modal de aviso de redefinição de faixas etárias

- Testes no modal de justificativa de redefinição de faixas


Referência no Azure: [AB#130730](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/130730)