### PR TITLE
feat(126063): :sparkles: Salvar e Assinar a Ficha de Recebimento

### DIFF
--- a/src/components/Shareable/ModalAssinaturaUsuario/index.jsx
+++ b/src/components/Shareable/ModalAssinaturaUsuario/index.jsx
@@ -18,6 +18,7 @@ export const ModalAssinaturaUsuario = ({
   handleSim,
   loading,
   titulo,
+  segundoTitulo = undefined,
   texto,
   textoBotao = "Sim, assinar cronograma",
 }) => {
@@ -35,7 +36,7 @@ export const ModalAssinaturaUsuario = ({
       <Spin tip="Carregando..." spinning={loading}>
         <Modal.Header closeButton>
           <Modal.Title>
-            {!concordaAssinar ? titulo : "Confirme sua senha"}
+            {!concordaAssinar ? titulo : segundoTitulo ?? "Confirme sua senha"}
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>

--- a/src/components/screens/Recebimento/FichaRecebimento/interfaces.ts
+++ b/src/components/screens/Recebimento/FichaRecebimento/interfaces.ts
@@ -27,6 +27,7 @@ export interface FichaRecebimentoPayload {
   observacoes_conferencia?: string;
   questoes?: QuestoesPayload[];
   ocorrencias?: OcorrenciaFichaRecebimento[];
+  password?: string;
 }
 
 export interface QuestoesPayload {

--- a/src/services/fichaRecebimento.service.ts
+++ b/src/services/fichaRecebimento.service.ts
@@ -6,6 +6,11 @@ import axios from "./_base";
 import { ResponseFichaRecebimento } from "src/interfaces/responses.interface";
 import { getMensagemDeErro } from "src/helpers/statusErrors";
 import { toastError } from "src/components/Shareable/Toast/dialogs";
+import { AxiosRequestConfig } from "axios";
+
+interface CustomAxiosRequestConfig extends AxiosRequestConfig {
+  skipAuthRefresh?: boolean;
+}
 
 export const cadastraRascunhoFichaRecebimento = async (
   payload: FichaRecebimentoPayload
@@ -14,6 +19,19 @@ export const cadastraRascunhoFichaRecebimento = async (
     return await axios.post("/rascunho-ficha-de-recebimento/", payload);
   } catch (error) {
     toastError(getMensagemDeErro(error.response.status));
+  }
+};
+
+export const cadastraFichaRecebimento = async (
+  payload: FichaRecebimentoPayload
+): Promise<ResponseFichaRecebimento> => {
+  try {
+    return await axios.post("/fichas-de-recebimento/", payload, {
+      skipAuthRefresh: true,
+    } as CustomAxiosRequestConfig);
+  } catch (error) {
+    if (error.response.status === 401) toastError(error.response.data[0]);
+    else toastError(getMensagemDeErro(error.response.status));
   }
 };
 


### PR DESCRIPTION
# Este PR

 - Modifica construção de payload para realizar o submit corretamente;
 - Implementa método para fazer chamada de endpoint;
 - Implementa parâmetro opcional de segundo título no Modal de Assinatura.

### Referência Azure

 - [AB#126063](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/126063)