### PR TITLE
Feature/132216 testes relatorio dietas canceladas

### DIFF
--- a/src/components/screens/DietaEspecial/RelatorioDietasCanceladas/__tests__/components/formulario_busca_dietas.test.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioDietasCanceladas/__tests__/components/formulario_busca_dietas.test.jsx
@@ -1,0 +1,118 @@
+import {
+  render,
+  screen,
+  act,
+  waitFor,
+  fireEvent,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL, TIPO_PERFIL } from "src/constants/shared";
+import mock from "src/services/_mock";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import { mockFiltrosRelatorioDietasEspeciais } from "src/mocks/services/dietaEspecial.service/mockGetFiltrosRelatorioDietasEspeciais";
+import { mockRelatorioDietasEpeciais } from "src/mocks/services/dietaEspecial.service/relatorioDietasEspeciaisTerceirizada";
+import { Filtros } from "../../components/Filtros";
+import { mockGetUnidadeEducacional } from "src/mocks/services/dietaEspecial.service/mockGetUnidadeEducacional";
+
+describe("Verifica comportamentos componente de filtros do relatório de dietas canceladas", () => {
+  const setUnidades = jest.fn();
+  beforeEach(async () => {
+    mock.onGet("/usuarios/meus-dados/").reply(200, mockMeusDadosCODAEGA);
+    mock
+      .onGet(
+        "/solicitacoes-dieta-especial/relatorio-dieta-especial-terceirizada/"
+      )
+      .reply(200, mockRelatorioDietasEpeciais);
+    mock
+      .onPost("/escolas-simplissima-com-eol/terc-total/")
+      .reply(200, mockGetUnidadeEducacional);
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <Filtros
+              erroAPI=""
+              filtros={mockFiltrosRelatorioDietasEspeciais}
+              meusDados={mockMeusDadosCODAEGA}
+              onClear={jest.fn()}
+              setDietasEspeciais={jest.fn()}
+              setLoadingDietas={jest.fn()}
+              setUnidadesEducacionais={setUnidades}
+              setValuesForm={jest.fn()}
+              unidadesEducacionais={[]}
+            />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  localStorage.setItem(
+    "tipo_perfil",
+    TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+  );
+  localStorage.setItem(
+    "perfil",
+    PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+  );
+
+  it("Verifica se o componente foi renderizado", () => {
+    expect(screen.getByText("Período de:")).toBeInTheDocument();
+    expect(screen.getByText("Até:")).toBeInTheDocument();
+    expect(screen.getByText("Filtrar")).toBeInTheDocument();
+    expect(screen.getByText("Limpar Filtros")).toBeInTheDocument();
+  });
+
+  const setData = async (id, valor) => {
+    const divData = screen.getByTestId(id);
+    const input = divData.querySelector("input");
+    await waitFor(async () => {
+      fireEvent.change(input, {
+        target: { value: valor },
+      });
+    });
+  };
+
+  it("Preenche campos de data e verifica se valores foram registrados", async () => {
+    setData("data-cancelamento-inicial", "01/01/2024");
+    setData("data-cancelamento-final", "31/01/2024");
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue("01/01/2024")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("31/01/2024")).toBeInTheDocument();
+    });
+  });
+
+  it("Preenche campo de data, limpa formulário e verifica se valores foi removido", async () => {
+    setData("data-cancelamento-inicial", "01/01/2024");
+    const botao = screen.getByText("Limpar Filtros").closest("button");
+    fireEvent.click(botao);
+    await waitFor(() => {
+      expect(screen.queryByDisplayValue("01/01/2024")).not.toBeInTheDocument();
+    });
+  });
+
+  it("Seleciona Lote e verifica se unidades foram carregadas", async () => {
+    const lotesSelect = screen.getByText("Selecione lotes");
+    fireEvent.click(lotesSelect);
+
+    const todosOpcao = screen.getByText("Todos");
+    fireEvent.click(todosOpcao);
+
+    await waitFor(() => {
+      expect(setUnidades).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/components/screens/DietaEspecial/RelatorioDietasCanceladas/__tests__/components/listagem_dietas_canceladas.test.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioDietasCanceladas/__tests__/components/listagem_dietas_canceladas.test.jsx
@@ -1,0 +1,65 @@
+import { act, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL, TIPO_PERFIL } from "src/constants/shared";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import { mockRelatorioDietasEpeciais } from "src/mocks/services/dietaEspecial.service/relatorioDietasEspeciaisTerceirizada";
+import { ListagemDietas } from "../../components/ListagemDietas";
+import mock from "src/services/_mock";
+
+describe("Verifica componente de tabela relatório de dietas canceladas", () => {
+  beforeEach(async () => {
+    mock
+      .onGet(
+        "/solicitacoes-dieta-especial/relatorio-dieta-especial-terceirizada/"
+      )
+      .reply(200, mockRelatorioDietasEpeciais);
+
+    localStorage.setItem(
+      "tipo_perfil",
+      TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <ListagemDietas
+              dietasEspeciais={mockRelatorioDietasEpeciais}
+              meusDados={mockMeusDadosCODAEGA}
+              setDietasEspeciais={jest.fn()}
+              setLoadingDietas={jest.fn()}
+              values={{
+                status_selecionado: "AUTORIZADAS",
+              }}
+            />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  it("Verifica se o componente foi renderizado com todos campos e registros", () => {
+    expect(screen.getByText("Nome da Escola")).toBeInTheDocument();
+    expect(screen.getByText("Nome do aluno")).toBeInTheDocument();
+    expect(
+      screen.getByText("RHUAN ANGELLO FERREIRA ABREU")
+    ).toBeInTheDocument();
+    expect(screen.getByText("MARTIN ABREU GUIMARAES")).toBeInTheDocument();
+  });
+});

--- a/src/components/screens/DietaEspecial/RelatorioDietasCanceladas/__tests__/erros/erro_carregar_filtros.test.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioDietasCanceladas/__tests__/erros/erro_carregar_filtros.test.jsx
@@ -1,0 +1,51 @@
+import { render, screen, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL, TIPO_PERFIL } from "src/constants/shared";
+import mock from "src/services/_mock";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import { RelatorioDietasCanceladas } from "../../";
+
+describe("Verifica comportamentos do relatório de dietas canceladas ao receber retorno de erro de filtros", () => {
+  beforeEach(async () => {
+    mock.onGet("/usuarios/meus-dados/").reply(200, mockMeusDadosCODAEGA);
+    mock
+      .onGet("/solicitacoes-dieta-especial/filtros-relatorio-dieta-especial/")
+      .reply(400, []);
+
+    localStorage.setItem(
+      "tipo_perfil",
+      TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <RelatorioDietasCanceladas />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  it("Verifica se o comportamento de erro foi exibido", () => {
+    expect(
+      screen.getByText("Erro ao carregar filtros. Tente novamente mais tarde.")
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/screens/DietaEspecial/RelatorioDietasCanceladas/__tests__/relatorio_dietas_canceladas.test.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioDietasCanceladas/__tests__/relatorio_dietas_canceladas.test.jsx
@@ -1,0 +1,93 @@
+import {
+  render,
+  screen,
+  act,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL, TIPO_PERFIL } from "src/constants/shared";
+import mock from "src/services/_mock";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import { mockFiltrosRelatorioDietasEspeciais } from "src/mocks/services/dietaEspecial.service/mockGetFiltrosRelatorioDietasEspeciais";
+import { mockRelatorioDietasEpeciais } from "src/mocks/services/dietaEspecial.service/relatorioDietasEspeciaisTerceirizada";
+import { RelatorioDietasCanceladas } from "..";
+import { mockGetUnidadeEducacional } from "src/mocks/services/dietaEspecial.service/mockGetUnidadeEducacional";
+
+describe("Verifica comportamentos do relatório de dietas canceladas", () => {
+  beforeEach(async () => {
+    mock.onGet("/usuarios/meus-dados/").reply(200, mockMeusDadosCODAEGA);
+    mock
+      .onGet("/solicitacoes-dieta-especial/filtros-relatorio-dieta-especial/")
+      .reply(200, mockFiltrosRelatorioDietasEspeciais);
+    mock
+      .onPost(
+        "/solicitacoes-genericas/filtrar-solicitacoes-cards-totalizadores/"
+      )
+      .reply(200, { results: [{ "Rede Municipal de Educação": 28 }] });
+    mock
+      .onGet(
+        "/solicitacoes-dieta-especial/relatorio-dieta-especial-terceirizada/"
+      )
+      .reply(200, mockRelatorioDietasEpeciais);
+    mock
+      .onPost("/escolas-simplissima-com-eol/terc-total/")
+      .reply(200, mockGetUnidadeEducacional);
+
+    localStorage.setItem(
+      "tipo_perfil",
+      TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <RelatorioDietasCanceladas />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  it("Verifica se o interface foi renderizada", () => {
+    expect(screen.getByText("Filtrar Resultados")).toBeInTheDocument();
+    expect(screen.getByText("Período de:")).toBeInTheDocument();
+    expect(screen.getByText("Até:")).toBeInTheDocument();
+    expect(screen.getByText("Filtrar")).toBeInTheDocument();
+    expect(screen.getByText("Limpar Filtros")).toBeInTheDocument();
+  });
+
+  it("Seleciona Lote, clica em filtrar e verifica se registros foram exibidos", async () => {
+    const lotesSelect = screen.getByText("Selecione lotes");
+    fireEvent.click(lotesSelect);
+
+    const todosOpcao = screen.getByText("Todos");
+    fireEvent.click(todosOpcao);
+
+    const botao = screen.getByText("Filtrar").closest("button");
+    fireEvent.click(botao);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("RHUAN ANGELLO FERREIRA ABREU")
+      ).toBeInTheDocument();
+      expect(screen.getByText("MARTIN ABREU GUIMARAES")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/screens/DietaEspecial/RelatorioDietasCanceladas/components/Filtros/index.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioDietasCanceladas/components/Filtros/index.jsx
@@ -94,6 +94,7 @@ export const Filtros = ({ ...props }) => {
                 <div className="row">
                   <div className="col-4">
                     <Field
+                      dataTestId="data-cancelamento-inicial"
                       component={InputComData}
                       label="Período de:"
                       name="data_cancelamento_inicial"
@@ -106,6 +107,7 @@ export const Filtros = ({ ...props }) => {
                   </div>
                   <div className="col-4">
                     <Field
+                      dataTestId="data-cancelamento-final"
                       component={InputComData}
                       label="Até:"
                       name="data_cancelamento_final"
@@ -122,6 +124,7 @@ export const Filtros = ({ ...props }) => {
                   <div className="col-4">
                     <label className="label fw-normal pb-2 pt-2">Lote</label>
                     <Field
+                      dataTestId="lotes-select"
                       component={StatefulMultiSelect}
                       name="lotes"
                       options={filtros.lotes.map((lote) => ({


### PR DESCRIPTION
Este pull request:
Implementa testes unitários para a interface de Relatório de Dietas Canceladas:
- Testes para formulário de buscas
- Testes para listagem de dietas

Referência no Azure: [AB#132216](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/132216)