### PR TITLE
Feature/129073 testes relatorio recreio nas ferias

### DIFF
--- a/src/components/screens/DietaEspecial/RelatorioRecreioFerias/__tests__/CODAE/relatorio.test.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioRecreioFerias/__tests__/CODAE/relatorio.test.jsx
@@ -138,4 +138,32 @@ describe("Teste Relatório Recreio Férias - Usuário CODAE", () => {
       fireEvent.click(botaoGerarProtocolo);
     });
   });
+
+  it("Clica botão de baixar PDF e recebe confirmação", async () => {
+    await act(async () => {
+      setDre(_DRE);
+    });
+
+    await act(async () => {
+      filtrar();
+    });
+
+    mock
+      .onGet(
+        "/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/exportar-pdf/"
+      )
+      .reply(200, {
+        detail: "Solicitação de geração de arquivo recebida com sucesso.",
+      });
+
+    const botao = screen.getByTestId("botao-gerar-pdf");
+    expect(botao).toBeInTheDocument();
+    await act(async () => fireEvent.click(botao));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Geração solicitada com sucesso.")
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/screens/DietaEspecial/RelatorioRecreioFerias/__tests__/erros/relatorio_erro_baixar_pdf.test.jsx
+++ b/src/components/screens/DietaEspecial/RelatorioRecreioFerias/__tests__/erros/relatorio_erro_baixar_pdf.test.jsx
@@ -1,0 +1,96 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import "@testing-library/jest-dom";
+import mock from "src/services/_mock";
+import { MemoryRouter } from "react-router-dom";
+import { PERFIL, TIPO_PERFIL } from "src/constants/shared";
+import { MeusDadosContext } from "src/context/MeusDadosContext";
+import { mockMeusDadosCODAEGA } from "src/mocks/meusDados/CODAE-GA";
+import { RelatorioRecreioFeriasPage } from "src/pages/DietaEspecial/RelatorioRecreioFeriasPage";
+import { mockLotesSimples } from "src/mocks/lote.service/mockLotesSimples";
+import { mockGetUnidadeEducacional } from "src/mocks/services/dietaEspecial.service/mockGetUnidadeEducacional";
+import { mockGetClassificacaoDieta } from "src/mocks/services/dietaEspecial.service/mockGetClassificacoesDietas";
+import { alergiasIntolerantes } from "src/components/screens/DietaEspecial/Relatorio/dados";
+import { mockRelatorioRecreioNasFerias } from "src/mocks/services/dietaEspecial.service/relatorioRecreioNasFerias";
+import { ToastContainer } from "react-toastify";
+
+describe("Verifica comportamento da interface ao receber retorno de erro na exportação de relatório - PDF", () => {
+  beforeEach(async () => {
+    mock.onGet("/usuarios/meus-dados/").reply(200, mockMeusDadosCODAEGA);
+    mock
+      .onGet("/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/")
+      .reply(200, mockRelatorioRecreioNasFerias);
+    mock.onGet("/lotes-simples/").reply(200, mockLotesSimples);
+    mock.onGet("/classificacoes-dieta/").reply(200, mockGetClassificacaoDieta);
+    mock.onGet("/alergias-intolerancias/").reply(200, alergiasIntolerantes());
+    mock
+      .onPost("/escolas-simplissima-com-eol/escolas-com-cod-eol/")
+      .reply(200, mockGetUnidadeEducacional);
+    localStorage.setItem(
+      "tipo_perfil",
+      TIPO_PERFIL.GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+    localStorage.setItem(
+      "perfil",
+      PERFIL.COORDENADOR_GESTAO_ALIMENTACAO_TERCEIRIZADA
+    );
+
+    await act(async () => {
+      render(
+        <MemoryRouter
+          future={{
+            v7_startTransition: true,
+            v7_relativeSplatPath: true,
+          }}
+        >
+          <MeusDadosContext.Provider
+            value={{
+              meusDados: mockMeusDadosCODAEGA,
+              setMeusDados: jest.fn(),
+            }}
+          >
+            <RelatorioRecreioFeriasPage />
+            <ToastContainer />
+          </MeusDadosContext.Provider>
+        </MemoryRouter>
+      );
+    });
+  });
+
+  it("Clica botão de baixar PDF e recebe erro", async () => {
+    await act(async () => {
+      const campoDre = screen.getByTestId("select-dre-lote");
+      const select = campoDre.querySelector("select");
+      fireEvent.change(select, {
+        target: { value: "775d49c5-9a84-4d5b-93e4-aa9d3a5f4459" },
+      });
+    });
+
+    await act(async () => {
+      const botaoFiltrar = screen.getByText("Filtrar");
+      expect(botaoFiltrar).toBeInTheDocument();
+      fireEvent.click(botaoFiltrar);
+    });
+
+    mock
+      .onGet(
+        "/solicitacoes-dieta-especial/relatorio-recreio-nas-ferias/exportar-pdf/"
+      )
+      .reply(400, {});
+
+    const botao = screen.getByTestId("botao-gerar-pdf");
+    expect(botao).toBeInTheDocument();
+    await act(async () => fireEvent.click(botao));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Erro ao baixar PDF. Tente novamente mais tarde")
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/screens/DietaEspecial/RelatorioRecreioFerias/index.tsx
+++ b/src/components/screens/DietaEspecial/RelatorioRecreioFerias/index.tsx
@@ -129,7 +129,7 @@ export const RelatorioRecreioFerias = () => {
                           type={BUTTON_TYPE.BUTTON}
                           style={BUTTON_STYLE.GREEN}
                           icon={BUTTON_ICON.FILE_PDF}
-                          onClick={async () => exportarPDF(valuesForm)}
+                          onClick={() => exportarPDF(valuesForm)}
                           className="ms-3"
                           disabled={loadingPdf}
                         />


### PR DESCRIPTION
Este pull request:
Implementa testes unitários para o Relatório de Dietas Autorizadas Recreio nas Férias:
- Teste para ação de botão "Baixar PDF".
- Teste em caso de erro ao gerar PDF.

Referência no Azure: [AB#129073](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/129073)