### PR TITLE
Feature/125028 editar rascunho ficha recebimento

### DIFF
--- a/src/components/screens/Recebimento/FichaRecebimento/components/Cadastrar/index.tsx
+++ b/src/components/screens/Recebimento/FichaRecebimento/components/Cadastrar/index.tsx
@@ -388,8 +388,7 @@ export default () => {
         setCarregando,
         setVeiculos,
         setOcorrenciasCount,
-        setArquivos,
-        setCollapse1
+        setArquivos
       );
     };
 

--- a/src/components/screens/Recebimento/FichaRecebimento/components/Cadastrar/index.tsx
+++ b/src/components/screens/Recebimento/FichaRecebimento/components/Cadastrar/index.tsx
@@ -48,7 +48,6 @@ import { exibeError } from "src/helpers/utilities";
 import { deletaValues } from "src/helpers/formHelper";
 import { stringToBoolean } from "src/helpers/parsers";
 import {
-  Arquivo,
   ArquivoForm,
   CronogramaSimples,
 } from "src/interfaces/pre_recebimento.interface";
@@ -99,11 +98,21 @@ const collapseConfigStep3 = [
   },
 ];
 
+const iniciaStateCollapse = () => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const uuid = urlParams.get("uuid");
+
+  if (!uuid) return { 0: true };
+  else return { 0: false, 1: true };
+};
+
 export default () => {
   const navigate = useNavigate();
   const [carregando, setCarregando] = useState<boolean>(true);
   const [cronogramas, setCronogramas] = useState<Array<CronogramaSimples>>([]);
-  const [collapse1, setCollapse1] = useState<CollapseControl>({ 0: true });
+  const [collapse1, setCollapse1] = useState<CollapseControl>(
+    iniciaStateCollapse()
+  );
   const [collapse2, setCollapse2] = useState<CollapseControl>({ 0: true });
   const [collapse3, setCollapse3] = useState<CollapseControl>({ 0: true });
   const [cronograma, setCronograma] = useState<CronogramaFicha>(
@@ -115,7 +124,7 @@ export default () => {
   const [showModalAssinatura, setShowModalAssinatura] = useState(false);
   const [stepAtual, setStepAtual] = useState(0);
   const [veiculos, setVeiculos] = useState([{}]);
-  const [arquivos, setArquivos] = useState<Arquivo[]>([]);
+  const [arquivos, setArquivos] = useState<ArquivoForm[]>([]);
   const [questoesPrimarias, setQuestoesPrimarias] = useState<
     QuestaoConferenciaSimples[]
   >([]);
@@ -186,6 +195,16 @@ export default () => {
           })
           .filter((x) => x !== null)
       : [];
+  };
+
+  const formataPayloadArquivos = (files: ArquivoForm[]) => {
+    const arquivosAtualizados = files.map((arquivo: ArquivoForm) => {
+      return {
+        nome: arquivo.nome,
+        arquivo: arquivo.base64,
+      };
+    });
+    return arquivosAtualizados;
   };
 
   const extraiOcorrenciasDoFormulario = (values: Record<string, any>) => {
@@ -294,7 +313,7 @@ export default () => {
           ? cronograma.sistema_vedacao_embalagem_secundaria
           : values.sistema_vedacao_embalagem_secundaria_outra_opcao,
       observacao: values.observacao,
-      arquivos: arquivos,
+      arquivos: formataPayloadArquivos(arquivos),
       observacoes_conferencia: values.observacoes_conferencia,
       questoes: questoes,
       ocorrencias: extraiOcorrenciasDoFormulario(values),
@@ -369,7 +388,8 @@ export default () => {
         setCarregando,
         setVeiculos,
         setOcorrenciasCount,
-        setArquivos
+        setArquivos,
+        setCollapse1
       );
     };
 
@@ -406,21 +426,19 @@ export default () => {
 
   useEffect(() => {
     if (initialValues.etapa && formRef.current && cronograma.etapas) {
-      setTimeout(() => {
-        const selectElement = document.querySelector(
-          'select[data-cy="Etapa e Parte"]'
-        ) as HTMLSelectElement;
-        if (selectElement) {
-          const optionToSelect = Array.from(selectElement.options).find(
-            (option) => option.value === initialValues.etapa.uuid
-          );
+      const selectElement = document.querySelector(
+        'select[data-cy="Etapa e Parte"]'
+      ) as HTMLSelectElement;
+      if (selectElement) {
+        const optionToSelect = Array.from(selectElement.options).find(
+          (option) => option.value === initialValues.etapa.uuid
+        );
 
-          if (optionToSelect) {
-            optionToSelect.selected = true;
-            selectElement.dispatchEvent(new Event("change", { bubbles: true }));
-          }
+        if (optionToSelect) {
+          optionToSelect.selected = true;
+          selectElement.dispatchEvent(new Event("change", { bubbles: true }));
         }
-      }, 200);
+      }
     }
   }, [cronograma.etapas, initialValues.etapa]);
 
@@ -510,14 +528,7 @@ export default () => {
   };
 
   const setFiles = (files: Array<ArquivoForm>): void => {
-    const arquivosAtualizados = files.map((arquivo: ArquivoForm) => {
-      return {
-        nome: arquivo.nome,
-        arquivo: arquivo.base64,
-      };
-    });
-
-    setArquivos(arquivosAtualizados);
+    setArquivos(files);
   };
 
   const removeFiles = (index: number): void => {
@@ -1481,6 +1492,7 @@ export default () => {
                             name="arquivo"
                             setFiles={setFiles}
                             removeFile={removeFiles}
+                            arquivosIniciais={arquivos as ArquivoForm[]}
                             toastSuccess="Documento incluído com sucesso!"
                             textoBotao="Anexar Documento"
                             helpText="Envie arquivos nos formatos: PDF, PNG, JPG ou JPEG  com até 10MB."

--- a/src/components/screens/Recebimento/FichaRecebimento/helpers.ts
+++ b/src/components/screens/Recebimento/FichaRecebimento/helpers.ts
@@ -4,7 +4,6 @@ import { getFichaRecebimentoDetalhada } from "../../../../services/fichaRecebime
 import { toastError } from "src/components/Shareable/Toast/dialogs";
 import { Arquivo, ArquivoForm } from "src/interfaces/pre_recebimento.interface";
 import { downloadAndConvertToBase64 } from "src/components/Shareable/Input/InputFile/helper";
-import { CollapseControl } from "src/components/Shareable/Collapse";
 
 export const carregarArquivo = async (arquivo: Arquivo) => {
   const file = {
@@ -21,18 +20,14 @@ export const carregarEdicaoFichaDeRecebimento = async (
   setCarregando: Dispatch<SetStateAction<boolean>>,
   setVeiculos?: Dispatch<SetStateAction<any[]>>,
   setOcorrenciasCount?: Dispatch<SetStateAction<number>>,
-  setArquivos?: Dispatch<SetStateAction<any[]>>,
-  setCollapse1?: Dispatch<SetStateAction<CollapseControl>>
+  setArquivos?: Dispatch<SetStateAction<any[]>>
 ) => {
   const urlParams = new URLSearchParams(window.location.search);
   const uuid = urlParams.get("uuid");
 
   if (!uuid) {
-    setCollapse1({ 0: true });
     return;
   }
-
-  setCollapse1({ 0: false, 1: true });
 
   try {
     setCarregando(true);

--- a/src/components/screens/Recebimento/FichaRecebimento/helpers.ts
+++ b/src/components/screens/Recebimento/FichaRecebimento/helpers.ts
@@ -2,20 +2,37 @@ import { Dispatch, SetStateAction } from "react";
 import { FichaRecebimentoDetalhada } from "../FichaRecebimento/interfaces";
 import { getFichaRecebimentoDetalhada } from "../../../../services/fichaRecebimento.service";
 import { toastError } from "src/components/Shareable/Toast/dialogs";
+import { Arquivo, ArquivoForm } from "src/interfaces/pre_recebimento.interface";
+import { downloadAndConvertToBase64 } from "src/components/Shareable/Input/InputFile/helper";
+import { CollapseControl } from "src/components/Shareable/Collapse";
+
+export const carregarArquivo = async (arquivo: Arquivo) => {
+  const file = {
+    nome: arquivo.nome,
+    arquivo: arquivo.arquivo,
+    base64: await downloadAndConvertToBase64(arquivo.arquivo),
+  };
+
+  return file;
+};
 
 export const carregarEdicaoFichaDeRecebimento = async (
   setInitialValues: Dispatch<SetStateAction<Record<string, any>>>,
   setCarregando: Dispatch<SetStateAction<boolean>>,
   setVeiculos?: Dispatch<SetStateAction<any[]>>,
   setOcorrenciasCount?: Dispatch<SetStateAction<number>>,
-  setArquivos?: Dispatch<SetStateAction<any[]>>
+  setArquivos?: Dispatch<SetStateAction<any[]>>,
+  setCollapse1?: Dispatch<SetStateAction<CollapseControl>>
 ) => {
   const urlParams = new URLSearchParams(window.location.search);
   const uuid = urlParams.get("uuid");
 
   if (!uuid) {
+    setCollapse1({ 0: true });
     return;
   }
+
+  setCollapse1({ 0: false, 1: true });
 
   try {
     setCarregando(true);
@@ -40,7 +57,12 @@ export const carregarEdicaoFichaDeRecebimento = async (
     }
 
     if (setArquivos && fichaRecebimento.arquivos) {
-      setArquivos(fichaRecebimento.arquivos);
+      const listaArquivos: ArquivoForm[] = [];
+      for (const arquivo of fichaRecebimento.arquivos) {
+        let arq = await carregarArquivo(arquivo);
+        listaArquivos.push(arq);
+      }
+      setArquivos(listaArquivos);
     }
 
     setInitialValues(geraInitialValuesCadastrar(fichaRecebimento));


### PR DESCRIPTION
# Este PR

- Ajusta o ato de Salvar Ficha de Recebimento quando arquivos são adicionados.
- Corrige comportamento do collapse para edição de Rascunho.

### Referência Azure

- [AB#125028](https://dev.azure.com/SME-Spassu/f77de57e-b4a4-4418-995e-9cba39dd8708/_workitems/edit/125028)