### PR TITLE
Hotfix/134836 corrige layout de embalagem sem secundaria

### DIFF
--- a/src/components/screens/PreRecebimento/LayoutEmbalagem/components/Corrigir/index.jsx
+++ b/src/components/screens/PreRecebimento/LayoutEmbalagem/components/Corrigir/index.jsx
@@ -100,10 +100,11 @@ export default ({ atualizar }) => {
       setArquivosLayoutsPrimarios
     );
 
-    await obterArquivosTipoDeEmbalagem(
-      layoutEmbalagensSecundarias,
-      setArquivosLayoutsSecundarios
-    );
+    layoutEmbalagensSecundarias &&
+      (await obterArquivosTipoDeEmbalagem(
+        layoutEmbalagensSecundarias,
+        setArquivosLayoutsSecundarios
+      ));
 
     layoutEmbalagensTerciarias &&
       (await obterArquivosTipoDeEmbalagem(

--- a/src/mocks/services/layoutDeEmbalagem.service/Terceirizada/mockDetalharLayoutEmbalagem.jsx
+++ b/src/mocks/services/layoutDeEmbalagem.service/Terceirizada/mockDetalharLayoutEmbalagem.jsx
@@ -59,3 +59,53 @@ export const mockDetalharLayoutEmbalagem = {
     },
   ],
 };
+
+export const mockDetalharLayoutEmbalagemSemSecundaria = {
+  uuid: "18143fe7-b9dd-4bb6-8c82-92337ced7b9c",
+  observacoes: "",
+  criado_em: "19/09/2025 16:05:34",
+  status: "Solicitado Correção",
+  tipos_de_embalagens: [
+    {
+      imagens: [
+        {
+          arquivo:
+            "http://localhost:8000/media/layouts_de_embalagens/a4e26aab-d35a-43ac-af1d-af3ae866984e.pdf",
+          nome: "relatorio_historico_dietas_especiais_17_04_2025 (1).pdf",
+        },
+      ],
+      uuid: "e9a46aaf-2a3b-46bb-90e4-ef3863acefc1",
+      tipo_embalagem: "PRIMARIA",
+      status: "REPROVADO",
+      complemento_do_status: "Teste 1",
+    },
+    null,
+    null,
+  ],
+  numero_ficha_tecnica: "FT023",
+  pregao_chamada_publica: "7625364",
+  nome_produto: "BOLACHINHA DE NATA",
+  nome_empresa: "JP Alimentos / JP Alimentos LTDA",
+  log_mais_recente: "19/09/2025 - 16:06",
+  primeira_analise: true,
+  logs: [
+    {
+      status_evento_explicacao: "Enviado para Análise",
+      usuario: {
+        uuid: "9f34bc68-ae58-41b1-a605-189824c9f7ef",
+        nome: "FORNECEDOR ADMIN",
+      },
+      criado_em: "19/09/2025 16:05:35",
+      justificativa: "",
+    },
+    {
+      status_evento_explicacao: "Solicitado Correção",
+      usuario: {
+        uuid: "9878774c-6264-47db-991c-ca30591138e1",
+        nome: "QUALIDADE",
+      },
+      criado_em: "19/09/2025 16:06:53",
+      justificativa: "",
+    },
+  ],
+};

--- a/src/pages/PreRecebimento/__tests__/teste_CorrigirLayoutEmbalagemPage.jsx
+++ b/src/pages/PreRecebimento/__tests__/teste_CorrigirLayoutEmbalagemPage.jsx
@@ -5,12 +5,16 @@ import mock from "src/services/_mock";
 import { MemoryRouter } from "react-router-dom";
 import CorrigirLayoutEmbalagemPage from "src/pages/PreRecebimento/CorrigirLayoutEmbalagemPage";
 import { MeusDadosContext } from "src/context/MeusDadosContext";
-
-import { mockDetalharLayoutEmbalagem } from "src/mocks/services/layoutDeEmbalagem.service/Terceirizada/mockDetalharLayoutEmbalagem";
+import {
+  mockDetalharLayoutEmbalagem,
+  mockDetalharLayoutEmbalagemSemSecundaria,
+} from "src/mocks/services/layoutDeEmbalagem.service/Terceirizada/mockDetalharLayoutEmbalagem";
 import { mockMeusDadosTerceirizadaAdmEmpresa } from "src/mocks/meusDados/terceirizada";
 import { localStorageMock } from "src/mocks/localStorageMock";
 
 import { PERFIL, TIPO_PERFIL } from "src/constants/shared";
+
+import { debug } from "jest-preview";
 
 describe("Teste <SolicitacoesAlimentacao> (RelatorioSolicitacoesAlimentacao)", () => {
   beforeEach(async () => {
@@ -63,7 +67,7 @@ describe("Teste <SolicitacoesAlimentacao> (RelatorioSolicitacoesAlimentacao)", (
     });
   });
 
-  it("Testa a renderização da página quando um dos tipos de embalagem é null", async () => {
+  it("Testa a renderização da página quando embalagem terciária é null", async () => {
     await waitFor(() => {
       expect(
         screen.getByText("FT023 - BOLACHINHA DE NATA")
@@ -73,5 +77,25 @@ describe("Teste <SolicitacoesAlimentacao> (RelatorioSolicitacoesAlimentacao)", (
     });
 
     expect(screen.queryAllByText("Embalagem Terciária")).toHaveLength(0);
+  });
+
+  it("Testa a renderização da página quando embalagens secundaria e terciaria são null", async () => {
+    mock
+      .onGet(
+        `/layouts-de-embalagem/${mockDetalharLayoutEmbalagemSemSecundaria.uuid}/`
+      )
+      .reply(200, mockDetalharLayoutEmbalagemSemSecundaria);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("FT023 - BOLACHINHA DE NATA")
+      ).toBeInTheDocument();
+      expect(screen.getByText("Teste 1")).toBeInTheDocument();
+    });
+
+    expect(screen.queryAllByText("Embalagem Secundária")).toHaveLength(0);
+    expect(screen.queryAllByText("Embalagem Terciária")).toHaveLength(0);
+
+    debug();
   });
 });


### PR DESCRIPTION
# Este PR 

- Adiciona código para verificar se tipo de embalagem possui valor definido antes de tentar acessar atributo 'imagens';
- Implementa teste unitário para validar funcionamento de página sem embalagem secundária.